### PR TITLE
disambiguated role specific llm params and fixed cli gaps for the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ All notable changes to CuratorKIT are documented here. The format follows
 ## Unreleased
 
 ### Added
+- YAML/CLI pipeline config (`PipelineConfig`) now mirrors `CuratorConfig`'s per-role LLM override
+  shape: new `generator_llm:`/`judge_llm:` mid-tier buckets, and a nested `<role>_llm:` block
+  (model/temperature/max_tokens/timeout/max_retries/extra_body/drop_params/concurrency) on
+  `hallucination`/`reward`/`toxicity` gates, generators, and the diagnostic probe — previously YAML
+  only had a single global `llm:` block plus a bare model-string override per role. Legacy bare
+  `*_llm_model` fields still work unchanged. Also closes two YAML-only feature gaps: `grpo_scoring_llm`
+  (GRPO rollouts previously reused the same LLM for scoring as for generation) and
+  `enable_reward_refiner`/`refiner_llm` (RewardRefiner had no YAML/CLI wiring at all). Quality gates
+  built via YAML also now receive a resolved `concurrency` (previously `HallucinationGate`/`RewardGate`
+  silently used their class defaults regardless of config).
+- `LLMOverride` (the per-role override dict passed to `generator_llm`, `judge_llm`,
+  `hallucination_llm`, `reward_llm`, `toxicity_llm`, `grpo_scoring_llm`, `probe_llm`,
+  `refiner_llm`) now accepts `temperature`, `max_tokens`, `timeout`, `max_retries`,
+  `extra_body`, `drop_params`, and `concurrency` — previously only `model`/`api_base`/
+  `api_key` were configurable per role, and the six non-generator/judge roles silently
+  ignored any sampling-param override because their call sites hardcoded literal
+  `temperature`/`max_tokens` values. All 8 roles now resolve through a consistent 3-tier
+  cascade (role override → mid-tier `judge_llm`/`generator_llm` → role default or global
+  bucket); default behavior is unchanged for anyone not setting a new field. `probe_llm`
+  and `refiner_llm` also gain a `concurrency` override (previously hardcoded to `32` with
+  no config path at all), and their forced `enable_thinking=False` extra_body injection now
+  respects an explicit user override instead of always clobbering it. `toxicity_llm.concurrency`
+  is accepted but has no effect yet — `ToxicityGate`'s LLM-judge path runs sequentially with
+  no executor.
 - SFT exporters (Alpaca, ShareGPT) warn when exported rows have empty
   instruction/output, catching task-type/format mismatches that previously
   produced silent empty datasets.

--- a/curatorkit/cli.py
+++ b/curatorkit/cli.py
@@ -107,7 +107,7 @@ def run(
                     shutil.rmtree(idx)
 
     splitting = bool(getattr(config, "output_split", None))
-    steps = _build_steps(config, verbose, include_exporters=not splitting)
+    steps, reward_refiner = _build_steps(config, verbose, include_exporters=not splitting)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     from curatorkit.manifest import DatasetCardGenerator, ProvenanceManifest
@@ -135,6 +135,17 @@ def run(
         result = asyncio.run(pipeline.run_async())
     else:
         result = pipeline.run()
+
+    # Reward refiner — post-pipeline recovery, same as Curator.run()'s handling
+    # of CuratorConfig.enable_reward_refiner.
+    if reward_refiner is not None:
+        reward_rejects = [r for r in result.rejected if r.rejecting_step == "RewardGate"]
+        if reward_rejects:
+            recovered, still_rejected = reward_refiner.refine(reward_rejects)
+            result.passed.extend(recovered)
+            result.rejected = [
+                r for r in result.rejected if r.rejecting_step != "RewardGate"
+            ] + still_rejected
 
     # Write diagnostic_summary.json when diagnostics were collected
     if result.diagnostics is not None:
@@ -322,15 +333,67 @@ def _print_dry_run_plan(config: object, output_dir: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _build_llm(model: str | None, config: object) -> object:
-    """Build an LLM backend from the global config or a model override."""
+def _pick(*values):
+    """Return the first value that is not None — cascade-resolution helper."""
+    for v in values:
+        if v is not None:
+            return v
+    return None
+
+
+def _mid_tier(config: object, role: str) -> object:
+    """Return the generator_llm/judge_llm mid-tier bucket, or an empty override if unset."""
+    from curatorkit.config import LLMOverrideConfig
+
+    bucket = config.generator_llm if role == "generation" else config.judge_llm
+    return bucket or LLMOverrideConfig()
+
+
+def _as_override(override, config: object) -> object:
+    """Coerce a bare model-name string (legacy) or None into an LLMOverrideConfig."""
+    from curatorkit.config import LLMOverrideConfig
+
+    if isinstance(override, str):
+        return LLMOverrideConfig(model=override)
+    if override is None:
+        return LLMOverrideConfig()
+    return override
+
+
+def _build_llm(
+    override: object,
+    config: object,
+    role: str = "generation",
+    role_defaults: dict | None = None,
+) -> object:
+    """Build an LLM backend via the 3-tier cascade: override -> mid-tier bucket -> role default/global.
+
+    `override` may be a bare model-name string (legacy `*_llm_model` fields),
+    an `LLMOverrideConfig`, or None. `role` is "generation" or "judging" and
+    selects the mid-tier bucket (`config.generator_llm` / `config.judge_llm`).
+    `role_defaults` is an optional {"temperature": ..., "max_tokens": ...}
+    dict (see `curatorkit.curator._ROLE_DEFAULT_LLM_PARAMS`) used as the
+    terminal fallback for temperature/max_tokens only — every other field
+    falls back to the global `llm:` block.
+    """
     from curatorkit.config import LLMConfig, PipelineConfig
     from curatorkit.llm.litellm import LiteLLMBackend
 
     assert isinstance(config, PipelineConfig)
     llm_cfg = config.llm or LLMConfig()
+    override = _as_override(override, config)
+    mid = _mid_tier(config, role)
+    defaults = role_defaults or {}
 
-    effective_model = model or llm_cfg.model
+    effective_model = _pick(override.model, mid.model, llm_cfg.model)
+    temperature = _pick(override.temperature, mid.temperature, defaults.get("temperature"), llm_cfg.temperature)
+    max_tokens = _pick(override.max_tokens, mid.max_tokens, defaults.get("max_tokens"), llm_cfg.max_tokens)
+    timeout = _pick(override.timeout, mid.timeout, llm_cfg.timeout)
+    max_retries = _pick(override.max_retries, mid.max_retries, llm_cfg.max_retries)
+    drop_params = _pick(override.drop_params, mid.drop_params, llm_cfg.drop_params)
+    extra_body = _pick(override.extra_body, mid.extra_body, llm_cfg.extra_body)
+    api_base = _pick(override.api_base, mid.api_base, llm_cfg.api_base)
+    api_key = _pick(override.api_key, mid.api_key, llm_cfg.api_key)
 
     # Route Ollama models to the Ollama backend
     if effective_model.startswith("ollama/") or effective_model.startswith("ollama_chat/"):
@@ -338,24 +401,31 @@ def _build_llm(model: str | None, config: object) -> object:
 
         return OllamaBackend(
             model=effective_model.split("/", 1)[1],
-            base_url=llm_cfg.api_base or "http://localhost:11434",
-            temperature=llm_cfg.temperature,
-            max_tokens=llm_cfg.max_tokens,
-            timeout=llm_cfg.timeout,
-            max_retries=llm_cfg.max_retries,
+            base_url=api_base or "http://localhost:11434",
+            temperature=temperature,
+            max_tokens=max_tokens,
+            timeout=timeout,
+            max_retries=max_retries,
         )
 
     return LiteLLMBackend(
         model=effective_model,
-        temperature=llm_cfg.temperature,
-        max_tokens=llm_cfg.max_tokens,
-        api_key=llm_cfg.api_key,
-        api_base=llm_cfg.api_base,
-        timeout=llm_cfg.timeout,
-        max_retries=llm_cfg.max_retries,
-        drop_params=llm_cfg.drop_params,
-        extra_body=llm_cfg.extra_body or None,
+        temperature=temperature,
+        max_tokens=max_tokens,
+        api_key=api_key,
+        api_base=api_base,
+        timeout=timeout,
+        max_retries=max_retries,
+        drop_params=drop_params,
+        extra_body=extra_body or None,
     )
+
+
+def _resolve_concurrency(override: object, config: object, role: str = "generation", default: int = 10) -> int:
+    """Resolve a role's executor concurrency: override -> mid-tier bucket -> default."""
+    override = _as_override(override, config)
+    mid = _mid_tier(config, role)
+    return _pick(override.concurrency, mid.concurrency, default)
 
 
 # ---------------------------------------------------------------------------
@@ -363,7 +433,11 @@ def _build_llm(model: str | None, config: object) -> object:
 # ---------------------------------------------------------------------------
 
 
-def _build_steps(config: object, verbose: bool, include_exporters: bool = True) -> list:
+def _build_steps(config: object, verbose: bool, include_exporters: bool = True) -> tuple[list, object | None]:
+    """Build the pipeline step list. Returns (steps, reward_refiner) — reward_refiner is
+    a RewardRefiner instance when `enable_reward_refiner` is set on a reward gate, else
+    None. It runs post-pipeline (see the `run` command), same as Curator.run()'s handling
+    of CuratorConfig.enable_reward_refiner."""
     from curatorkit.config import PipelineConfig
     from curatorkit.connectors.csv_reader import CSVReader
     from curatorkit.connectors.huggingface import HuggingFaceReader
@@ -382,6 +456,7 @@ def _build_steps(config: object, verbose: bool, include_exporters: bool = True) 
 
     assert isinstance(config, PipelineConfig)
     steps = []
+    reward_refiner = None
 
     # ---- Readers ----
     for r in config.readers:
@@ -533,9 +608,15 @@ def _build_steps(config: object, verbose: bool, include_exporters: bool = True) 
                 )
             )
         elif g.type == "toxicity":
+            from curatorkit.curator import _ROLE_DEFAULT_LLM_PARAMS
             from curatorkit.hygiene.toxicity import ToxicityGate
 
-            tox_llm = _build_llm(g.toxicity_llm_model, config) if g.toxicity_llm_model else None
+            _tox_override = g.toxicity_llm or g.toxicity_llm_model
+            tox_llm = (
+                _build_llm(_tox_override, config, role="judging", role_defaults=_ROLE_DEFAULT_LLM_PARAMS["toxicity"])
+                if _tox_override
+                else None
+            )
             steps.append(
                 ToxicityGate(
                     classifier_pass_threshold=g.toxicity_classifier_pass_threshold,
@@ -549,8 +630,8 @@ def _build_steps(config: object, verbose: bool, include_exporters: bool = True) 
 
     # ---- Generation tasks ----
     for gen in config.generators:
-        llm = _build_llm(gen.llm_model, config)
-        concurrency = config.llm.concurrency if config.llm else 10
+        llm = _build_llm(gen.llm or gen.llm_model, config, role="generation")
+        concurrency = _resolve_concurrency(gen.llm or gen.llm_model, config, role="generation", default=config.llm.concurrency if config.llm else 10)
 
         if gen.type == "qa":
             from curatorkit.generators.qa_generator import QAGenerationTask
@@ -593,11 +674,18 @@ def _build_steps(config: object, verbose: bool, include_exporters: bool = True) 
                 )
             )
         elif gen.type == "grpo":
+            from curatorkit.curator import _ROLE_DEFAULT_LLM_PARAMS
             from curatorkit.generators.grpo_rollout import GRPORolloutTask
 
+            scoring_llm = (
+                _build_llm(gen.grpo_scoring_llm, config, role="judging", role_defaults=_ROLE_DEFAULT_LLM_PARAMS["grpo_scoring"])
+                if gen.score_responses
+                else None
+            )
             steps.append(
                 GRPORolloutTask(
                     llm=llm,
+                    scoring_llm=scoring_llm,
                     response_prompt=gen.prompt_template,
                     num_responses=gen.num_responses,
                     score_responses=gen.score_responses,
@@ -664,22 +752,29 @@ def _build_steps(config: object, verbose: bool, include_exporters: bool = True) 
     # ---- Quality gates (after generation) ----
     for g in config.gates:
         if g.type == "hallucination":
+            from curatorkit.curator import _ROLE_DEFAULT_LLM_PARAMS
             from curatorkit.gates.hallucination import HallucinationGate
 
-            llm = _build_llm(g.hallucination_llm_model, config)
+            _hall_override = g.hallucination_llm or g.hallucination_llm_model
+            llm = _build_llm(_hall_override, config, role="judging", role_defaults=_ROLE_DEFAULT_LLM_PARAMS["hallucination"])
             gate = HallucinationGate(
                 llm=llm,
                 threshold=g.hallucination_threshold,
                 prompt_template=g.hallucination_prompt_template,
                 skip_if_no_context=g.skip_if_no_context,
+                concurrency=_resolve_concurrency(_hall_override, config, role="judging", default=16),
             )
             # ── Attach diagnostic probe if configured ───────────────────
             if config.diagnostic is not None and config.diagnostic.enable_probe:
                 from curatorkit.diagnostic.probe import DiagnosticProbe
 
+                _probe_override = (
+                    config.diagnostic.probe_llm
+                    or config.diagnostic.probe_generator_model
+                    or _hall_override
+                )
                 probe_llm = _build_llm(
-                    config.diagnostic.probe_generator_model or g.hallucination_llm_model,
-                    config,
+                    _probe_override, config, role="generation", role_defaults=_ROLE_DEFAULT_LLM_PARAMS["probe"]
                 )
                 gate.probe = DiagnosticProbe(
                     generator_llm=probe_llm,
@@ -687,21 +782,37 @@ def _build_steps(config: object, verbose: bool, include_exporters: bool = True) 
                     temperatures=config.diagnostic.probe_temperatures,
                     score_split=config.diagnostic.score_split,
                     extra_templates=config.diagnostic.extra_templates or None,
+                    concurrency=_resolve_concurrency(_probe_override, config, role="generation", default=32),
                 )
             steps.append(gate)
         elif g.type == "reward":
+            from curatorkit.curator import _ROLE_DEFAULT_LLM_PARAMS
             from curatorkit.gates.reward import RewardGate
 
-            llm = _build_llm(g.reward_llm_model, config)
-            steps.append(
-                RewardGate(
-                    llm=llm,
-                    threshold=g.reward_threshold,
-                    dimensions=g.reward_dimensions,
-                    prompt_template=g.reward_prompt_template,
-                    store_score_in_label=g.store_score_in_label,
-                )
+            _reward_override = g.reward_llm or g.reward_llm_model
+            llm = _build_llm(_reward_override, config, role="judging", role_defaults=_ROLE_DEFAULT_LLM_PARAMS["reward"])
+            reward_gate = RewardGate(
+                llm=llm,
+                threshold=g.reward_threshold,
+                dimensions=g.reward_dimensions,
+                prompt_template=g.reward_prompt_template,
+                store_score_in_label=g.store_score_in_label,
+                concurrency=_resolve_concurrency(_reward_override, config, role="judging", default=16),
             )
+            if g.enable_reward_refiner:
+                from curatorkit.diagnostic.reward_refine import RewardRefiner
+
+                refiner_llm = _build_llm(
+                    g.refiner_llm, config, role="generation", role_defaults=_ROLE_DEFAULT_LLM_PARAMS["refiner"]
+                )
+                reward_refiner = RewardRefiner(
+                    generator_llm=refiner_llm,
+                    reward_gate=reward_gate,
+                    refine_prompt_template=g.reward_refine_prompt_template,
+                    instruction_refine_template=g.reward_instruction_refine_template,
+                    concurrency=_resolve_concurrency(g.refiner_llm, config, role="generation", default=32),
+                )
+            steps.append(reward_gate)
         elif g.type == "diversity":
             from curatorkit.gates.diversity import DiversityGate
 
@@ -761,7 +872,7 @@ def _build_steps(config: object, verbose: bool, include_exporters: bool = True) 
             elif e.type == "dpo":
                 steps.append(DPOExporter())
 
-    return steps
+    return steps, reward_refiner
 
 
 @app.command("setup-pdf")

--- a/curatorkit/config.py
+++ b/curatorkit/config.py
@@ -134,6 +134,34 @@ class LLMConfig(BaseModel):
     extra_body: dict = Field(default_factory=dict)
 
 
+class LLMOverrideConfig(BaseModel):
+    """Per-role LLM override for the YAML/CLI pipeline — mirrors `curator.LLMOverride`.
+
+    Every field is optional; unset (`None`) means "inherit from the next
+    tier" (a role's own `<role>_llm:` block → the `generator_llm:`/
+    `judge_llm:` mid-tier bucket → the global `llm:` block, or a
+    role-specific historical default for temperature/max_tokens — see
+    `curatorkit.curator._ROLE_DEFAULT_LLM_PARAMS`).
+
+    Can be set directly as a nested YAML block:
+        hallucination_llm:
+          model: openai/gpt-4o-mini
+          temperature: 0.0
+          max_tokens: 300
+    """
+
+    model: str | None = None
+    api_base: str | None = None
+    api_key: str | None = None
+    temperature: float | None = None
+    max_tokens: int | None = None
+    timeout: float | None = None
+    max_retries: int | None = None
+    extra_body: dict | None = None
+    drop_params: bool | None = None
+    concurrency: int | None = None
+
+
 # =========================================================================
 # Diagnostic probe configuration
 # =========================================================================
@@ -151,8 +179,10 @@ class DiagnosticConfig(BaseModel):
     enable_probe: bool = False
     probe_temperatures: list[float] = Field(default_factory=lambda: [0.3, 0.5])
     # Override generator model for re-generation in the probe.
-    # If None, uses the gate's LLM model.
+    # If None, uses the gate's LLM model. Legacy model-only override.
     probe_generator_model: str | None = None
+    # Full sampling-param override (model, temperature, max_tokens, concurrency, ...).
+    probe_llm: LLMOverrideConfig | None = None
     # Grounding score threshold below which the probe routes to strict-grounding first.
     score_split: float = 0.5
     # Extra prompt templates merged with built-ins; keys used as template names in probe routing.
@@ -232,7 +262,11 @@ class GenerationConfig(BaseModel):
     reward_prompt_template: str | None = None
 
     # ---- LLM override (uses global LLM config if None) ----
-    llm_model: str | None = None
+    llm_model: str | None = None  # legacy model-only override; kept for backward compat
+    llm: LLMOverrideConfig | None = None  # generator role — full sampling-param override
+
+    # ---- GRPO scoring LLM override ----
+    grpo_scoring_llm: LLMOverrideConfig | None = None
 
 
 # =========================================================================
@@ -267,7 +301,8 @@ class GateConfig(BaseModel):
     # ---- Hallucination gate ----
     hallucination_threshold: float = 0.7
     skip_if_no_context: bool = True
-    hallucination_llm_model: str | None = None  # override global LLM
+    hallucination_llm_model: str | None = None  # legacy model-only override
+    hallucination_llm: LLMOverrideConfig | None = None  # full sampling-param override
     hallucination_prompt_template: str | None = None
 
     # ---- Reward gate ----
@@ -276,8 +311,15 @@ class GateConfig(BaseModel):
         default_factory=lambda: ["helpfulness", "honesty", "instruction_following"]
     )
     store_score_in_label: bool = True
-    reward_llm_model: str | None = None  # override global LLM
+    reward_llm_model: str | None = None  # legacy model-only override
+    reward_llm: LLMOverrideConfig | None = None  # full sampling-param override
     reward_prompt_template: str | None = None
+
+    # ---- Reward refiner (post-gate recovery) ----
+    enable_reward_refiner: bool = False
+    refiner_llm: LLMOverrideConfig | None = None
+    reward_refine_prompt_template: str | None = None
+    reward_instruction_refine_template: str | None = None
 
     # ---- Diversity gate ----
     embedding_model: str = "sentence-transformers/all-MiniLM-L6-v2"
@@ -297,7 +339,8 @@ class GateConfig(BaseModel):
     toxicity_classifier_pass_threshold: float = 0.1
     toxicity_classifier_reject_threshold: float = 0.5
     toxicity_detoxify_model: str = "unbiased"
-    toxicity_llm_model: str | None = None
+    toxicity_llm_model: str | None = None  # legacy model-only override
+    toxicity_llm: LLMOverrideConfig | None = None  # full sampling-param override
     toxicity_llm_reject_threshold: float = 0.5
     toxicity_text_field: str = "auto"
 
@@ -422,6 +465,10 @@ class PipelineConfig(BaseModel):
 
     # ---- Global LLM config ----
     llm: LLMConfig | None = None
+
+    # ---- Mid-tier LLM buckets (fall back to `llm:` global) ----
+    generator_llm: LLMOverrideConfig | None = None
+    judge_llm: LLMOverrideConfig | None = None
 
     # ---- Generation tasks ----
     generators: list[GenerationConfig] = Field(default_factory=list)

--- a/curatorkit/curator.py
+++ b/curatorkit/curator.py
@@ -67,19 +67,46 @@ except ImportError:
 
 @dataclass
 class LLMOverride:
-    """Per-task or per-role LLM routing override.
+    """Per-task or per-role LLM routing + sampling override.
 
-    Each field cascades independently:
-      task-level → role-level (generator_llm / judge_llm) → global llm_* fields.
+    Each field cascades independently through up to three tiers:
+      task-level → role-level (generator_llm / judge_llm, or for the six
+      "second-class" roles, their own override → generator_llm / judge_llm)
+      → global llm_* / judge_llm_* fields (or a role-specific historical
+      default for temperature/max_tokens — see _ROLE_DEFAULT_LLM_PARAMS).
     Leave a field as None to inherit from the next level.
 
     Can be passed as a dict and will be coerced automatically by CuratorConfig:
-        generator_llm={"model": "openai/gpt-4o", "api_key": "sk-..."}
+        generator_llm={"model": "openai/gpt-4o", "temperature": 0.7}
+        hallucination_llm={"model": "openai/gpt-4o-mini", "temperature": 0.0, "concurrency": 5}
     """
 
     model: str | None = None
     api_base: str | None = None
     api_key: str | None = None
+    temperature: float | None = None
+    max_tokens: int | None = None
+    timeout: float | None = None
+    max_retries: int | None = None
+    extra_body: dict | None = None
+    drop_params: bool | None = None
+    concurrency: int | None = None
+
+
+# Historical per-call-site defaults for the six roles that don't have a
+# dedicated flat CuratorConfig bucket (unlike generator/judge). These preserve
+# today's behavior as the terminal fallback when neither the role's own
+# LLMOverride nor its mid-tier bucket (generator_llm/judge_llm) sets a value.
+# probe's temperature is intentionally None — it's swept per-call via
+# DiagnosticProbe.temperatures, so no single fallback constant applies.
+_ROLE_DEFAULT_LLM_PARAMS: dict[str, dict[str, float | int | None]] = {
+    "hallucination": {"temperature": 0.1, "max_tokens": 512},
+    "reward": {"temperature": 0.1, "max_tokens": 512},
+    "toxicity": {"temperature": 0.1, "max_tokens": 200},
+    "grpo_scoring": {"temperature": 0.1, "max_tokens": 256},
+    "probe": {"temperature": None, "max_tokens": 512},
+    "refiner": {"temperature": 0.4, "max_tokens": 512},
+}
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -872,7 +899,7 @@ class Curator:
         if cfg.toxicity_gate:
             from curatorkit.hygiene.toxicity import ToxicityGate
 
-            _tox_llm = self._build_judge_backend(cfg.toxicity_llm) if cfg.toxicity_llm_judge and cfg._any_judge_model() else None
+            _tox_llm = self._build_toxicity_backend(cfg.toxicity_llm) if cfg.toxicity_llm_judge and cfg._any_judge_model() else None
             steps.append(
                 ToxicityGate(
                     classifier_pass_threshold=cfg.toxicity_classifier_pass_threshold,
@@ -898,8 +925,8 @@ class Curator:
         if cfg.hallucination_threshold is not None and cfg._any_judge_model():
             from curatorkit.gates.hallucination import HallucinationGate
 
-            llm = self._build_judge_backend(cfg.hallucination_llm)
-            _jconcurrency = cfg.judge_concurrency or cfg.llm_concurrency
+            llm = self._build_hallucination_backend(cfg.hallucination_llm)
+            _jconcurrency = self._resolve_role_concurrency(cfg.hallucination_llm, cfg.judge_llm, cfg.judge_concurrency or cfg.llm_concurrency)
             gate = HallucinationGate(
                 llm=llm,
                 threshold=cfg.hallucination_threshold,
@@ -917,6 +944,7 @@ class Curator:
                     temperatures=cfg.probe_temperatures,
                     score_split=cfg.probe_score_split,
                     extra_templates=cfg.probe_extra_templates or None,
+                    concurrency=self._resolve_role_concurrency(cfg.probe_llm, cfg.generator_llm, 32),
                 )
                 if PipelineDiagnostics is not None:
                     self._diagnostics = PipelineDiagnostics()
@@ -926,14 +954,14 @@ class Curator:
         if cfg.reward_threshold is not None and cfg._any_judge_model():
             from curatorkit.gates.reward import RewardGate
 
-            llm = self._build_judge_backend(cfg.reward_llm)
+            llm = self._build_reward_backend(cfg.reward_llm)
             _reward_gate = RewardGate(
                 llm=llm,
                 threshold=cfg.reward_threshold,
                 dimensions=cfg.reward_dimensions,
                 prompt_template=cfg.reward_prompt_template,
                 store_score_in_label=cfg.reward_store_score,
-                concurrency=cfg.judge_concurrency or cfg.llm_concurrency,
+                concurrency=self._resolve_role_concurrency(cfg.reward_llm, cfg.judge_llm, cfg.judge_concurrency or cfg.llm_concurrency),
             )
             # Attach DiagnosticProbe to RewardGate when probe is enabled
             if cfg.enable_diagnostic_probe:
@@ -946,6 +974,7 @@ class Curator:
                     temperatures=cfg.probe_temperatures,
                     score_split=cfg.probe_score_split,
                     extra_templates=cfg.probe_extra_templates or None,
+                    concurrency=self._resolve_role_concurrency(cfg.probe_llm, cfg.generator_llm, 32),
                 )
 
             steps.append(_reward_gate)
@@ -960,6 +989,7 @@ class Curator:
                     reward_gate=_reward_gate,
                     refine_prompt_template=cfg.reward_refine_prompt_template,
                     instruction_refine_template=cfg.reward_instruction_refine_template,
+                    concurrency=self._resolve_role_concurrency(cfg.refiner_llm, cfg.generator_llm, 32),
                 )
 
         if cfg.diversity_threshold is not None:
@@ -1085,73 +1115,143 @@ class Curator:
             extra_body=extra_body or None,
         )
 
+    @staticmethod
+    def _pick(*values):
+        """Return the first value that is not None — cascade-resolution helper."""
+        for v in values:
+            if v is not None:
+                return v
+        return None
+
+    def _apply_forced_thinking_off(self, extra_body: dict) -> dict:
+        """Force enable_thinking=False for probe/refiner, unless the caller set it explicitly.
+
+        Probe/refiner calls must produce structured text without reasoning
+        preamble, so this is forced by default — but a role override that
+        explicitly sets chat_template_kwargs.enable_thinking is respected.
+        """
+        import copy
+
+        merged = copy.deepcopy(extra_body or {})
+        ctk = merged.setdefault("chat_template_kwargs", {})
+        if "enable_thinking" not in ctk:
+            ctk["enable_thinking"] = False
+        return merged
+
     def _build_gen_llm(self, task_llm: LLMOverride):
         """Build a generation backend — cascades task_llm → generator_llm → global."""
         cfg = self.config
         resolved = cfg._resolve(task_llm, "generation")
+        g = cfg.generator_llm
+        pick = self._pick
         return self._make_backend(
             resolved,
-            temperature=cfg.llm_temperature,
-            max_tokens=cfg.llm_max_tokens,
-            timeout=cfg.llm_timeout,
-            max_retries=cfg.llm_max_retries,
-            drop_params=cfg.llm_drop_params,
-            extra_body=cfg.llm_extra_body,
+            temperature=pick(task_llm.temperature, g.temperature, cfg.llm_temperature),
+            max_tokens=pick(task_llm.max_tokens, g.max_tokens, cfg.llm_max_tokens),
+            timeout=pick(task_llm.timeout, g.timeout, cfg.llm_timeout),
+            max_retries=pick(task_llm.max_retries, g.max_retries, cfg.llm_max_retries),
+            drop_params=pick(task_llm.drop_params, g.drop_params, cfg.llm_drop_params),
+            extra_body=pick(task_llm.extra_body, g.extra_body, cfg.llm_extra_body),
         )
 
     def _build_judge_backend(self, task_llm: LLMOverride):
         """Build a judge backend — cascades task_llm → judge_llm → global."""
         cfg = self.config
         resolved = cfg._resolve(task_llm, "judging")
+        j = cfg.judge_llm
+        pick = self._pick
         return self._make_backend(
             resolved,
-            temperature=cfg.judge_llm_temperature,
-            max_tokens=cfg.judge_llm_max_tokens,
-            timeout=cfg.judge_llm_timeout,
-            max_retries=cfg.judge_llm_max_retries,
-            drop_params=cfg.llm_drop_params,
-            extra_body=cfg.judge_llm_extra_body,
+            temperature=pick(task_llm.temperature, j.temperature, cfg.judge_llm_temperature),
+            max_tokens=pick(task_llm.max_tokens, j.max_tokens, cfg.judge_llm_max_tokens),
+            timeout=pick(task_llm.timeout, j.timeout, cfg.judge_llm_timeout),
+            max_retries=pick(task_llm.max_retries, j.max_retries, cfg.judge_llm_max_retries),
+            drop_params=pick(task_llm.drop_params, j.drop_params, cfg.llm_drop_params),
+            extra_body=pick(task_llm.extra_body, j.extra_body, cfg.judge_llm_extra_body),
         )
 
-    def _build_probe_backend(self):
-        """Build probe backend (generation role) with thinking disabled.
+    def _build_role_judge_backend(self, role_llm: LLMOverride, role: str):
+        """Build a backend for one of the judging-routed second-class roles.
 
-        Probe calls must produce structured text without reasoning preamble.
-        Thinking is disabled at the API level regardless of llm_extra_body.
+        3-tier cascade: role_llm → judge_llm → role-specific historical
+        default (temperature/max_tokens) or the judge bucket (everything else).
+        `role` must be a key of _ROLE_DEFAULT_LLM_PARAMS ("hallucination",
+        "reward", "toxicity", "grpo_scoring").
         """
         cfg = self.config
-        import copy
-
-        probe_extra = copy.deepcopy(cfg.llm_extra_body or {})
-        probe_extra.setdefault("chat_template_kwargs", {})["enable_thinking"] = False
-        resolved = cfg._resolve(cfg.probe_llm, "generation")
+        resolved = cfg._resolve(role_llm, "judging")
+        j = cfg.judge_llm
+        defaults = _ROLE_DEFAULT_LLM_PARAMS[role]
+        pick = self._pick
         return self._make_backend(
             resolved,
-            temperature=cfg.llm_temperature,
-            max_tokens=cfg.llm_max_tokens,
-            timeout=cfg.llm_timeout,
-            max_retries=cfg.llm_max_retries,
-            drop_params=cfg.llm_drop_params,
-            extra_body=probe_extra,
+            temperature=pick(role_llm.temperature, j.temperature, defaults["temperature"]),
+            max_tokens=pick(role_llm.max_tokens, j.max_tokens, defaults["max_tokens"]),
+            timeout=pick(role_llm.timeout, j.timeout, cfg.judge_llm_timeout),
+            max_retries=pick(role_llm.max_retries, j.max_retries, cfg.judge_llm_max_retries),
+            drop_params=pick(role_llm.drop_params, j.drop_params, cfg.llm_drop_params),
+            extra_body=pick(role_llm.extra_body, j.extra_body, cfg.judge_llm_extra_body),
+        )
+
+    def _build_hallucination_backend(self, task_llm: LLMOverride):
+        return self._build_role_judge_backend(task_llm, "hallucination")
+
+    def _build_reward_backend(self, task_llm: LLMOverride):
+        return self._build_role_judge_backend(task_llm, "reward")
+
+    def _build_toxicity_backend(self, task_llm: LLMOverride):
+        return self._build_role_judge_backend(task_llm, "toxicity")
+
+    def _build_grpo_scoring_backend(self, task_llm: LLMOverride):
+        return self._build_role_judge_backend(task_llm, "grpo_scoring")
+
+    def _build_probe_backend(self):
+        """Build probe backend (generation role) with thinking disabled by default.
+
+        Probe calls must produce structured text without reasoning preamble —
+        forced unless probe_llm.extra_body explicitly sets enable_thinking.
+        """
+        cfg = self.config
+        g = cfg.generator_llm
+        defaults = _ROLE_DEFAULT_LLM_PARAMS["probe"]
+        pick = self._pick
+        resolved = cfg._resolve(cfg.probe_llm, "generation")
+        extra_body = self._apply_forced_thinking_off(
+            pick(cfg.probe_llm.extra_body, g.extra_body, cfg.llm_extra_body)
+        )
+        return self._make_backend(
+            resolved,
+            temperature=pick(cfg.probe_llm.temperature, g.temperature, defaults["temperature"], cfg.llm_temperature),
+            max_tokens=pick(cfg.probe_llm.max_tokens, g.max_tokens, defaults["max_tokens"]),
+            timeout=pick(cfg.probe_llm.timeout, g.timeout, cfg.llm_timeout),
+            max_retries=pick(cfg.probe_llm.max_retries, g.max_retries, cfg.llm_max_retries),
+            drop_params=pick(cfg.probe_llm.drop_params, g.drop_params, cfg.llm_drop_params),
+            extra_body=extra_body,
         )
 
     def _build_refiner_backend(self):
-        """Build refiner backend (generation role) with thinking disabled."""
+        """Build refiner backend (generation role) with thinking disabled by default."""
         cfg = self.config
-        import copy
-
-        refiner_extra = copy.deepcopy(cfg.llm_extra_body or {})
-        refiner_extra.setdefault("chat_template_kwargs", {})["enable_thinking"] = False
+        g = cfg.generator_llm
+        defaults = _ROLE_DEFAULT_LLM_PARAMS["refiner"]
+        pick = self._pick
         resolved = cfg._resolve(cfg.refiner_llm, "generation")
+        extra_body = self._apply_forced_thinking_off(
+            pick(cfg.refiner_llm.extra_body, g.extra_body, cfg.llm_extra_body)
+        )
         return self._make_backend(
             resolved,
-            temperature=cfg.llm_temperature,
-            max_tokens=cfg.llm_max_tokens,
-            timeout=cfg.llm_timeout,
-            max_retries=cfg.llm_max_retries,
-            drop_params=cfg.llm_drop_params,
-            extra_body=refiner_extra,
+            temperature=pick(cfg.refiner_llm.temperature, g.temperature, defaults["temperature"]),
+            max_tokens=pick(cfg.refiner_llm.max_tokens, g.max_tokens, defaults["max_tokens"]),
+            timeout=pick(cfg.refiner_llm.timeout, g.timeout, cfg.llm_timeout),
+            max_retries=pick(cfg.refiner_llm.max_retries, g.max_retries, cfg.llm_max_retries),
+            drop_params=pick(cfg.refiner_llm.drop_params, g.drop_params, cfg.llm_drop_params),
+            extra_body=extra_body,
         )
+
+    def _resolve_role_concurrency(self, role_llm: LLMOverride, mid_tier_llm: LLMOverride, default: int) -> int:
+        """Resolve a role's executor concurrency: role_llm → mid-tier (judge_llm/generator_llm) → default."""
+        return self._pick(role_llm.concurrency, mid_tier_llm.concurrency, default)
 
     # ─────────────────────────────────────────────────────────────────────────
     # Generation task builder
@@ -1161,7 +1261,7 @@ class Curator:
         """Build the generation task from config, using per-task LLM overrides."""
         cfg = self.config
         task = cfg.generation_task
-        concurrency = cfg.generation_concurrency or cfg.llm_concurrency
+        concurrency = self._pick(cfg.generator_llm.concurrency, cfg.generation_concurrency, cfg.llm_concurrency)
 
         # Map each task to its task-level LLMOverride — cascades to generator_llm → global
         llm = self._build_gen_llm(LLMOverride())
@@ -1191,12 +1291,14 @@ class Curator:
         elif task == "grpo":
             from curatorkit.generators.grpo_rollout import GRPORolloutTask
 
-            # grpo_scoring_llm cascades: task override → judge_llm → global.
+            # grpo_scoring_llm cascades: task override → judge_llm → role default → global.
             # Old grpo_scoring_llm_model field used as model-only fallback.
             _score_override = cfg.grpo_scoring_llm
             if not _score_override.model and cfg.grpo_scoring_llm_model:
-                _score_override = LLMOverride(model=cfg.grpo_scoring_llm_model)
-            scoring_llm = self._build_judge_backend(_score_override) if cfg.score_responses else None
+                _score_override = LLMOverride(model=cfg.grpo_scoring_llm_model, **{
+                    k: v for k, v in vars(cfg.grpo_scoring_llm).items() if k != "model"
+                })
+            scoring_llm = self._build_grpo_scoring_backend(_score_override) if cfg.score_responses else None
             return GRPORolloutTask(
                 llm=llm,
                 scoring_llm=scoring_llm,

--- a/curatorkit/diagnostic/probe.py
+++ b/curatorkit/diagnostic/probe.py
@@ -70,11 +70,13 @@ class DiagnosticProbe:
         temperatures: list[float] | None = None,
         score_split: float = _DEFAULT_SCORE_SPLIT,
         extra_templates: dict[str, str] | None = None,
+        concurrency: int = 32,
     ) -> None:
         self.generator_llm = generator_llm
         self.gate = gate
         self.temperatures = temperatures or [0.3, 0.5]
         self.score_split = score_split
+        self.concurrency = concurrency
 
         # Merge user-supplied templates with the built-ins; user values take precedence.
         if extra_templates:
@@ -113,18 +115,20 @@ class DiagnosticProbe:
     def diagnose_batch(
         self,
         rejected: list[RejectedSample],
-        concurrency: int = 32,
+        concurrency: int | None = None,
     ) -> list[FailureDiagnosis]:
         """
         Diagnose all rejected samples concurrently.
 
-        Runs up to `concurrency` samples in parallel — each sample's probe
+        Runs up to `concurrency` samples in parallel (defaults to the value
+        set at construction time, `self.concurrency`) — each sample's probe
         sequence is still sequential internally (each result conditions the
         next probe), but different samples proceed independently. A single
         tqdm bar tracks the batch.
         """
         if not rejected:
             return []
+        concurrency = concurrency if concurrency is not None else self.concurrency
 
         results: list[FailureDiagnosis | None] = [None] * len(rejected)
         lock = threading.Lock()
@@ -537,7 +541,7 @@ class DiagnosticProbe:
             resp = self.generator_llm.generate(
                 messages=[{"role": "user", "content": prompt}],
                 temperature=temperature,
-                max_tokens=512,
+                max_tokens=self.generator_llm.max_tokens,
             )
         except Exception as exc:
             logger.debug("Probe re-generation failed T=%.1f: %s", temperature, exc)
@@ -578,7 +582,7 @@ class DiagnosticProbe:
             resp = self.generator_llm.generate(
                 messages=[{"role": "user", "content": prompt}],
                 temperature=self.temperatures[0],
-                max_tokens=128,
+                max_tokens=self.generator_llm.max_tokens,
             )
         except Exception as exc:
             logger.debug("Probe instruction re-generation failed: %s", exc)

--- a/curatorkit/diagnostic/reward_refine.py
+++ b/curatorkit/diagnostic/reward_refine.py
@@ -198,8 +198,8 @@ class RewardRefiner(BaseNormalizer):
         try:
             resp = self.generator_llm.generate(
                 [{"role": "user", "content": prompt}],
-                temperature=0.4,
-                max_tokens=512,
+                temperature=self.generator_llm.temperature,
+                max_tokens=self.generator_llm.max_tokens,
             )
         except Exception as exc:
             logger.debug("RewardRefiner answer rewrite failed: %s", exc)
@@ -220,8 +220,8 @@ class RewardRefiner(BaseNormalizer):
         try:
             resp = self.generator_llm.generate(
                 [{"role": "user", "content": prompt}],
-                temperature=0.4,
-                max_tokens=128,
+                temperature=self.generator_llm.temperature,
+                max_tokens=self.generator_llm.max_tokens,
             )
         except Exception as exc:
             logger.debug("RewardRefiner instruction rewrite failed: %s", exc)

--- a/curatorkit/gates/hallucination.py
+++ b/curatorkit/gates/hallucination.py
@@ -301,8 +301,8 @@ class HallucinationGate(BaseGate):
 
         response = self.llm.generate(
             [{"role": "user", "content": prompt}],
-            temperature=0.1,
-            max_tokens=512,
+            temperature=self.llm.temperature,
+            max_tokens=self.llm.max_tokens,
         )
 
         text = response.text.strip()
@@ -344,8 +344,8 @@ class HallucinationGate(BaseGate):
         )
         response = await self.llm.agenerate(
             [{"role": "user", "content": prompt}],
-            temperature=0.1,
-            max_tokens=512,
+            temperature=self.llm.temperature,
+            max_tokens=self.llm.max_tokens,
         )
         text = response.text.strip()
         text = re.sub(r"```(?:json)?\s*", "", text)

--- a/curatorkit/gates/reward.py
+++ b/curatorkit/gates/reward.py
@@ -390,8 +390,8 @@ class RewardGate(BaseGate):
 
         resp = self.llm.generate(
             [{"role": "user", "content": prompt}],
-            temperature=0.1,
-            max_tokens=512,
+            temperature=self.llm.temperature,
+            max_tokens=self.llm.max_tokens,
         )
 
         text = resp.text.strip()
@@ -437,8 +437,8 @@ class RewardGate(BaseGate):
         prompt = self._build_reward_prompt(instruction, response)
         resp = await self.llm.agenerate(
             [{"role": "user", "content": prompt}],
-            temperature=0.1,
-            max_tokens=512,
+            temperature=self.llm.temperature,
+            max_tokens=self.llm.max_tokens,
         )
         text = resp.text.strip()
         text = re.sub(r"```(?:json)?\s*", "", text)

--- a/curatorkit/generators/grpo_rollout.py
+++ b/curatorkit/generators/grpo_rollout.py
@@ -168,8 +168,8 @@ class GRPORolloutTask(BaseGenerationTask):
         try:
             resp = self.scoring_llm.generate(
                 [{"role": "user", "content": prompt}],
-                temperature=0.1,
-                max_tokens=256,
+                temperature=self.scoring_llm.temperature,
+                max_tokens=self.scoring_llm.max_tokens,
             )
             text = resp.text.strip()
             text = re.sub(r"```(?:json)?\s*", "", text)

--- a/curatorkit/hygiene/toxicity.py
+++ b/curatorkit/hygiene/toxicity.py
@@ -196,8 +196,8 @@ class ToxicityGate(BaseGate):
         try:
             response = self.llm.generate(
                 messages=[{"role": "user", "content": prompt}],
-                temperature=0.1,
-                max_tokens=200,
+                temperature=self.llm.temperature,
+                max_tokens=self.llm.max_tokens,
             )
             m = re.search(r"\{[^{}]+\}", response.text, re.DOTALL)
             if m:

--- a/docs/guides/quality-gates.md
+++ b/docs/guides/quality-gates.md
@@ -59,6 +59,21 @@ CuratorConfig(
 
 **Same-model warning:** If `judge_llm_model` is the same model as `llm_model`, the judge scores its own outputs leniently. Use a different model for the judge whenever possible.
 
+**Per-gate sampling params:** `hallucination_llm`/`reward_llm`/`toxicity_llm` accept the same
+dict-of-fields as `judge_llm` — set a gate-specific `temperature`/`max_tokens`/`concurrency` etc.
+without touching the shared judge bucket:
+
+```python
+CuratorConfig(
+    hallucination_threshold = 0.7,
+    judge_llm_model         = "openai/gpt-4o",
+    hallucination_llm       = {"temperature": 0.0, "max_tokens": 300},  # gate-specific override
+)
+```
+
+See [Per-role LLM overrides](../reference/configuration.md#per-role-llm-overrides-llmoverride) for
+the full field list and cascade order.
+
 ---
 
 ## RewardGate

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -173,6 +173,101 @@ Used by HallucinationGate and RewardGate. Defaults to the generator LLM when not
 
 ---
 
+## Per-role LLM overrides (`LLMOverride`)
+
+CuratorConfig exposes one `LLMOverride` field per LLM "role": `generator_llm`, `judge_llm`,
+`hallucination_llm`, `reward_llm`, `toxicity_llm`, `grpo_scoring_llm`, `probe_llm`, `refiner_llm`.
+Each accepts a plain dict — it's coerced into an `LLMOverride` automatically — with any of ten
+fields: `model`, `api_base`, `api_key`, `temperature`, `max_tokens`, `timeout`, `max_retries`,
+`extra_body`, `drop_params`, `concurrency`. Leave a field unset (`None`) to inherit it from the next
+tier down.
+
+```python
+config = CuratorConfig(
+    dataset="my-dataset",
+    llm_model="openai/gpt-4o-mini",
+    hallucination_llm={"model": "openai/gpt-4o-mini", "temperature": 0.0, "max_tokens": 300},
+    toxicity_llm={"model": "openai/gpt-4o-mini", "temperature": 0.0},
+    refiner_llm={"temperature": 0.5, "concurrency": 8},
+)
+```
+
+**Resolution is a 3-tier cascade** — role-specific override → mid-tier bucket → terminal default:
+
+| Role | Mid-tier bucket | Terminal default (temperature / max_tokens) |
+|------|------------------|----------------------------------------------|
+| `generator_llm` | — (top of the generation branch) | `llm_temperature` / `llm_max_tokens` |
+| `judge_llm` | — (top of the judging branch) | `judge_llm_temperature` / `judge_llm_max_tokens` |
+| `hallucination_llm` | `judge_llm` | `0.1` / `512` |
+| `reward_llm` | `judge_llm` | `0.1` / `512` |
+| `toxicity_llm` | `judge_llm` | `0.1` / `200` |
+| `grpo_scoring_llm` | `judge_llm` | `0.1` / `256` |
+| `probe_llm` | `generator_llm` | *(temperature swept per-call)* / `512` |
+| `refiner_llm` | `generator_llm` | `0.4` / `512` |
+
+`timeout`/`max_retries`/`extra_body`/`drop_params` for the six second-class roles fall back to the
+judging bucket (`hallucination_llm`/`reward_llm`/`toxicity_llm`/`grpo_scoring_llm`) or generation
+bucket (`probe_llm`/`refiner_llm`) — there's no historical mismatch there, unlike temperature/max_tokens.
+
+`concurrency` controls executor parallelism for the role's gate/task wrapper (e.g.
+`HallucinationGate`, `DiagnosticProbe`, `RewardRefiner`) — it cascades the same way, falling back to
+`judge_concurrency`/`generation_concurrency`/`llm_concurrency` (or `32` for probe/refiner, which had
+no config knob at all before this).
+
+**`enable_thinking`**: `probe_llm`/`refiner_llm` force `chat_template_kwargs.enable_thinking = False`
+by default (probe/refiner need structured text, not a reasoning preamble) — but if you explicitly set
+`enable_thinking` in the role's `extra_body`, that value is respected instead of being overwritten.
+
+This same per-role override shape is also available in the YAML/CLI pipeline config — see
+[YAML per-role LLM overrides](#yaml-per-role-llm-overrides) below.
+
+---
+
+## YAML per-role LLM overrides
+
+The YAML/CLI pipeline config (`PipelineConfig`) mirrors `CuratorConfig`'s per-role override shape.
+Two new top-level mid-tier buckets, `generator_llm:` and `judge_llm:`, sit between each role's own
+override and the global `llm:` block:
+
+```yaml
+llm:
+  model: openai/gpt-4o-mini
+judge_llm:
+  temperature: 0.1          # applies to hallucination/reward/toxicity/grpo_scoring by default
+
+gates:
+  - type: hallucination
+    hallucination_threshold: 0.7
+    hallucination_llm:                 # per-gate override — wins over judge_llm:
+      model: openai/gpt-4o-mini
+      temperature: 0.0
+      max_tokens: 300
+      concurrency: 5
+  - type: reward
+    reward_threshold: 0.7
+    enable_reward_refiner: true        # previously unavailable in YAML at all
+    refiner_llm:
+      temperature: 0.5
+      concurrency: 8
+
+generators:
+  - type: grpo
+    llm_model: openai/gpt-4o-mini
+    grpo_scoring_llm:                  # previously unavailable in YAML at all
+      model: openai/gpt-4o
+      temperature: 0.05
+```
+
+The legacy bare model-string fields (`hallucination_llm_model`, `reward_llm_model`,
+`toxicity_llm_model`, `llm_model` on a generator, `probe_generator_model`) still work unchanged —
+they're treated as `{model: "..."}` shorthand and only apply when the corresponding nested block
+(`hallucination_llm:`, etc.) is absent.
+
+Same 3-tier cascade and role-default table as the Python API (see above), including the
+`enable_thinking` behavior.
+
+---
+
 ## Generation task
 
 | Parameter | Type | Default | Description |

--- a/tests/unit/test_cli_llm_resolution.py
+++ b/tests/unit/test_cli_llm_resolution.py
@@ -1,0 +1,209 @@
+"""
+Regression tests for YAML/CLI per-role LLM override parity with CuratorConfig.
+
+Before this change, the YAML/CLI pipeline surface (curatorkit/config.py +
+curatorkit/cli.py) had only one global `llm:` bucket and bare `*_llm_model`
+model-string overrides per role — no judging/generation bucket split, no
+per-role temperature/max_tokens/concurrency, and `grpo_scoring`/`refiner`
+weren't exposed at all. These tests cover the new `LLMOverrideConfig` nested
+blocks, the `generator_llm:`/`judge_llm:` mid-tier buckets, the 3-tier
+cascade shared with the Python API's `_ROLE_DEFAULT_LLM_PARAMS`, backward
+compatibility with the legacy bare-string fields, and the two newly-exposed
+features (`grpo_scoring_llm`, `enable_reward_refiner`/`refiner_llm`).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("litellm", reason="litellm not installed — install curatorkit[generation]")
+
+from curatorkit.cli import _build_steps
+from curatorkit.config import (
+    DiagnosticConfig,
+    GateConfig,
+    GenerationConfig,
+    LLMConfig,
+    PipelineConfig,
+    ReaderConfig,
+)
+
+
+def _base_config(**overrides) -> PipelineConfig:
+    defaults = {
+        "readers": [ReaderConfig(type="jsonl", path="dummy.jsonl")],
+        "llm": LLMConfig(model="openai/gpt-4o-mini"),
+    }
+    return PipelineConfig(**{**defaults, **overrides})
+
+
+class TestLegacyBackwardCompat:
+    def test_bare_model_string_still_works_for_hallucination(self):
+        cfg = _base_config(
+            gates=[GateConfig(type="hallucination", hallucination_threshold=0.7, hallucination_llm_model="openai/gpt-4o")]
+        )
+        steps, _ = _build_steps(cfg, verbose=False)
+        from curatorkit.gates.hallucination import HallucinationGate
+
+        gate = next(s for s in steps if isinstance(s, HallucinationGate))
+        assert gate.llm.model == "openai/gpt-4o"
+
+    def test_bare_model_string_still_works_for_generator(self):
+        cfg = _base_config(generators=[GenerationConfig(type="qa", llm_model="openai/gpt-4o")])
+        steps, _ = _build_steps(cfg, verbose=False)
+        from curatorkit.generators.qa_generator import QAGenerationTask
+
+        gen = next(s for s in steps if isinstance(s, QAGenerationTask))
+        assert gen.llm.model == "openai/gpt-4o"
+
+
+class TestNestedOverrideBlocks:
+    def test_hallucination_llm_nested_block_sets_sampling_params(self):
+        cfg = _base_config(
+            gates=[
+                GateConfig(
+                    type="hallucination",
+                    hallucination_threshold=0.7,
+                    hallucination_llm={"model": "openai/gpt-4o-mini", "temperature": 0.0, "max_tokens": 300},
+                )
+            ]
+        )
+        steps, _ = _build_steps(cfg, verbose=False)
+        from curatorkit.gates.hallucination import HallucinationGate
+
+        gate = next(s for s in steps if isinstance(s, HallucinationGate))
+        assert gate.llm.temperature == 0.0
+        assert gate.llm.max_tokens == 300
+
+    def test_hallucination_default_matches_historical_literal(self):
+        cfg = _base_config(gates=[GateConfig(type="hallucination", hallucination_threshold=0.7)])
+        steps, _ = _build_steps(cfg, verbose=False)
+        from curatorkit.gates.hallucination import HallucinationGate
+
+        gate = next(s for s in steps if isinstance(s, HallucinationGate))
+        assert gate.llm.temperature == 0.1
+        assert gate.llm.max_tokens == 512
+
+    def test_toxicity_default_matches_historical_literal(self):
+        cfg = _base_config(
+            gates=[GateConfig(type="toxicity", toxicity_llm={"model": "openai/gpt-4o-mini"})]
+        )
+        steps, _ = _build_steps(cfg, verbose=False)
+        from curatorkit.hygiene.toxicity import ToxicityGate
+
+        gate = next(s for s in steps if isinstance(s, ToxicityGate))
+        assert gate.llm.temperature == 0.1
+        assert gate.llm.max_tokens == 200
+
+
+class TestCascade:
+    def test_judge_llm_mid_tier_beats_global_bucket(self):
+        cfg = _base_config(
+            judge_llm={"temperature": 0.55},
+            gates=[GateConfig(type="reward", reward_threshold=0.7)],
+        )
+        steps, _ = _build_steps(cfg, verbose=False)
+        from curatorkit.gates.reward import RewardGate
+
+        gate = next(s for s in steps if isinstance(s, RewardGate))
+        assert gate.llm.temperature == 0.55
+
+    def test_role_override_beats_judge_llm_mid_tier(self):
+        cfg = _base_config(
+            judge_llm={"temperature": 0.55},
+            gates=[GateConfig(type="reward", reward_threshold=0.7, reward_llm={"temperature": 0.11})],
+        )
+        steps, _ = _build_steps(cfg, verbose=False)
+        from curatorkit.gates.reward import RewardGate
+
+        gate = next(s for s in steps if isinstance(s, RewardGate))
+        assert gate.llm.temperature == 0.11
+
+    def test_generator_llm_mid_tier_beats_global_bucket(self):
+        cfg = _base_config(
+            generator_llm={"temperature": 0.25},
+            generators=[GenerationConfig(type="qa")],
+        )
+        steps, _ = _build_steps(cfg, verbose=False)
+        from curatorkit.generators.qa_generator import QAGenerationTask
+
+        gen = next(s for s in steps if isinstance(s, QAGenerationTask))
+        assert gen.llm.temperature == 0.25
+
+
+class TestConcurrencyWiring:
+    def test_hallucination_gate_now_receives_concurrency(self):
+        """Previously HallucinationGate() in cli.py was never passed a concurrency=
+        argument at all — it silently used the class default (16)."""
+        cfg = _base_config(
+            gates=[
+                GateConfig(
+                    type="hallucination",
+                    hallucination_threshold=0.7,
+                    hallucination_llm={"concurrency": 3},
+                )
+            ]
+        )
+        steps, _ = _build_steps(cfg, verbose=False)
+        from curatorkit.gates.hallucination import HallucinationGate
+
+        gate = next(s for s in steps if isinstance(s, HallucinationGate))
+        assert gate.concurrency == 3
+
+    def test_diagnostic_probe_receives_concurrency(self):
+        cfg = _base_config(
+            gates=[GateConfig(type="hallucination", hallucination_threshold=0.7)],
+            diagnostic=DiagnosticConfig(enable_probe=True, probe_llm={"concurrency": 9}),
+        )
+        steps, _ = _build_steps(cfg, verbose=False)
+        from curatorkit.gates.hallucination import HallucinationGate
+
+        gate = next(s for s in steps if isinstance(s, HallucinationGate))
+        assert gate.probe is not None
+        assert gate.probe.concurrency == 9
+
+
+class TestNewlyExposedFeatures:
+    def test_grpo_scoring_llm_now_exposed(self):
+        """CuratorConfig has always had grpo_scoring_llm; the YAML/CLI path had no
+        equivalent at all — the rollout LLM was reused for scoring too."""
+        cfg = _base_config(
+            generators=[
+                GenerationConfig(
+                    type="grpo",
+                    llm_model="openai/gpt-4o-mini",
+                    grpo_scoring_llm={"model": "openai/gpt-4o", "temperature": 0.05},
+                )
+            ]
+        )
+        steps, _ = _build_steps(cfg, verbose=False)
+        from curatorkit.generators.grpo_rollout import GRPORolloutTask
+
+        gen = next(s for s in steps if isinstance(s, GRPORolloutTask))
+        assert gen.scoring_llm.model == "openai/gpt-4o"
+        assert gen.scoring_llm.temperature == 0.05
+        assert gen.scoring_llm is not gen.llm
+
+    def test_enable_reward_refiner_now_exposed(self):
+        """RewardRefiner had no YAML/CLI wiring at all before this change."""
+        cfg = _base_config(
+            gates=[
+                GateConfig(
+                    type="reward",
+                    reward_threshold=0.7,
+                    enable_reward_refiner=True,
+                    refiner_llm={"temperature": 0.9, "concurrency": 5},
+                )
+            ]
+        )
+        steps, reward_refiner = _build_steps(cfg, verbose=False)
+        from curatorkit.diagnostic.reward_refine import RewardRefiner
+
+        assert isinstance(reward_refiner, RewardRefiner)
+        assert reward_refiner.generator_llm.temperature == 0.9
+        assert reward_refiner.concurrency == 5
+
+    def test_no_refiner_when_flag_unset(self):
+        cfg = _base_config(gates=[GateConfig(type="reward", reward_threshold=0.7)])
+        _, reward_refiner = _build_steps(cfg, verbose=False)
+        assert reward_refiner is None

--- a/tests/unit/test_hygiene.py
+++ b/tests/unit/test_hygiene.py
@@ -224,6 +224,18 @@ class TestToxicityGateLLMPhase:
         with pytest.raises(ValueError):
             ToxicityGate(classifier_pass_threshold=0.5, classifier_reject_threshold=0.3)
 
+    def test_llm_verdict_reads_temperature_and_max_tokens_from_backend(self):
+        """Regression: _llm_verdict used to hardcode temperature=0.1, max_tokens=200
+        directly in the .generate() call, silently ignoring the backend's own
+        configured values. It must now read self.llm.temperature/.max_tokens."""
+        gate = self._make_gate_with_llm(classifier_score=0.25, llm_score=0.2)
+        gate.llm.temperature = 0.777
+        gate.llm.max_tokens = 4242
+        gate.run([make_sample()])
+        _, kwargs = gate.llm.generate.call_args
+        assert kwargs["temperature"] == 0.777
+        assert kwargs["max_tokens"] == 4242
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # SecretsGate

--- a/tests/unit/test_llm_override_params.py
+++ b/tests/unit/test_llm_override_params.py
@@ -1,0 +1,337 @@
+"""
+Regression tests for per-role LLM sampling-param overrides.
+
+Historically, LLMOverride only carried model/api_base/api_key — sampling
+params (temperature, max_tokens, timeout, max_retries, extra_body,
+drop_params, concurrency) were configurable only for generator/judge via flat
+CuratorConfig fields, and the other six roles (hallucination, reward,
+toxicity, grpo_scoring, probe, refiner) hardcoded literal temperature/
+max_tokens at their .generate()/.agenerate() call sites — so even editing
+e.g. toxicity_llm={"temperature": ...} had no effect. These tests cover the
+new 3-tier cascade (task/role override -> mid-tier bucket -> role default or
+global bucket) added to close that gap, plus the default-preservation
+regression guard (no override set -> resolves to the exact pre-existing
+hardcoded literal).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("litellm", reason="litellm not installed — install curatorkit[generation]")
+
+from curatorkit.curator import _ROLE_DEFAULT_LLM_PARAMS, Curator, CuratorConfig, LLMOverride
+
+
+def _config(**overrides) -> CuratorConfig:
+    defaults = {"dataset": "dummy.jsonl", "llm_model": "openai/gpt-4o-mini"}
+    return CuratorConfig(**{**defaults, **overrides})
+
+
+JUDGING_ROLES = ["hallucination", "reward", "toxicity", "grpo_scoring"]
+_BUILDER_METHOD = {
+    "hallucination": "_build_hallucination_backend",
+    "reward": "_build_reward_backend",
+    "toxicity": "_build_toxicity_backend",
+    "grpo_scoring": "_build_grpo_scoring_backend",
+}
+
+
+class TestLLMOverrideBackwardCompat:
+    def test_model_only_dataclass_construction_still_works(self):
+        ov = LLMOverride(model="openai/gpt-4o")
+        assert ov.model == "openai/gpt-4o"
+        assert ov.temperature is None
+        assert ov.concurrency is None
+
+    def test_dict_coercion_accepts_new_fields(self):
+        cfg = _config(
+            hallucination_llm={"model": "openai/gpt-4o-mini", "temperature": 0.3, "max_tokens": 999}
+        )
+        assert isinstance(cfg.hallucination_llm, LLMOverride)
+        assert cfg.hallucination_llm.temperature == 0.3
+        assert cfg.hallucination_llm.max_tokens == 999
+
+
+class TestJudgingRoleDefaults:
+    """No override set -> backend matches the pre-existing hardcoded literal."""
+
+    @pytest.mark.parametrize("role", JUDGING_ROLES)
+    def test_default_matches_historical_literal(self, role):
+        cfg = _config()
+        curator = Curator(cfg)
+        builder = getattr(curator, _BUILDER_METHOD[role])
+        backend = builder(getattr(cfg, f"{role}_llm"))
+        defaults = _ROLE_DEFAULT_LLM_PARAMS[role]
+        assert backend.temperature == defaults["temperature"]
+        assert backend.max_tokens == defaults["max_tokens"]
+
+
+class TestJudgingRoleOverrides:
+    @pytest.mark.parametrize("role", JUDGING_ROLES)
+    def test_role_override_takes_effect(self, role):
+        cfg = _config(**{f"{role}_llm": {"model": "openai/gpt-4o-mini", "temperature": 0.33, "max_tokens": 777}})
+        curator = Curator(cfg)
+        builder = getattr(curator, _BUILDER_METHOD[role])
+        backend = builder(getattr(cfg, f"{role}_llm"))
+        assert backend.temperature == 0.33
+        assert backend.max_tokens == 777
+
+    @pytest.mark.parametrize("role", JUDGING_ROLES)
+    def test_cascade_role_beats_judge_llm_beats_role_default(self, role):
+        cfg = _config(judge_llm={"temperature": 0.55})
+        curator = Curator(cfg)
+        builder = getattr(curator, _BUILDER_METHOD[role])
+        backend = builder(getattr(cfg, f"{role}_llm"))
+        # judge_llm mid-tier beats the role-specific historical default
+        assert backend.temperature == 0.55
+
+        cfg2 = _config(
+            judge_llm={"temperature": 0.55},
+            **{f"{role}_llm": {"temperature": 0.11}},
+        )
+        curator2 = Curator(cfg2)
+        builder2 = getattr(curator2, _BUILDER_METHOD[role])
+        backend2 = builder2(getattr(cfg2, f"{role}_llm"))
+        # role-specific override beats judge_llm mid-tier
+        assert backend2.temperature == 0.11
+
+
+class TestGeneratorJudgeOverrides:
+    def test_generator_llm_override_now_respected(self):
+        cfg = _config(generator_llm={"temperature": 0.25, "max_tokens": 333})
+        backend = Curator(cfg)._build_gen_llm(LLMOverride())
+        assert backend.temperature == 0.25
+        assert backend.max_tokens == 333
+
+    def test_generator_llm_unset_falls_back_to_global_bucket(self):
+        cfg = _config(llm_temperature=0.42, llm_max_tokens=111)
+        backend = Curator(cfg)._build_gen_llm(LLMOverride())
+        assert backend.temperature == 0.42
+        assert backend.max_tokens == 111
+
+    def test_judge_llm_override_now_respected(self):
+        cfg = _config(judge_llm={"temperature": 0.05, "max_tokens": 42})
+        backend = Curator(cfg)._build_judge_backend(LLMOverride())
+        assert backend.temperature == 0.05
+        assert backend.max_tokens == 42
+
+
+class TestProbeRefinerDefaults:
+    def test_probe_default_max_tokens_unified(self):
+        cfg = _config()
+        backend = Curator(cfg)._build_probe_backend()
+        assert backend.max_tokens == _ROLE_DEFAULT_LLM_PARAMS["probe"]["max_tokens"]
+
+    def test_refiner_default_matches_historical_literal(self):
+        cfg = _config()
+        backend = Curator(cfg)._build_refiner_backend()
+        defaults = _ROLE_DEFAULT_LLM_PARAMS["refiner"]
+        assert backend.temperature == defaults["temperature"]
+        assert backend.max_tokens == defaults["max_tokens"]
+
+    def test_probe_override_takes_effect(self):
+        cfg = _config(probe_llm={"max_tokens": 64})
+        backend = Curator(cfg)._build_probe_backend()
+        assert backend.max_tokens == 64
+
+    def test_refiner_override_takes_effect(self):
+        cfg = _config(refiner_llm={"temperature": 0.9, "max_tokens": 64})
+        backend = Curator(cfg)._build_refiner_backend()
+        assert backend.temperature == 0.9
+        assert backend.max_tokens == 64
+
+
+class TestEnableThinkingForceOverride:
+    def test_default_forces_thinking_off(self):
+        cfg = _config()
+        backend = Curator(cfg)._build_probe_backend()
+        assert backend.extra_body["chat_template_kwargs"]["enable_thinking"] is False
+
+    def test_explicit_override_is_respected(self):
+        cfg = _config(
+            probe_llm={"extra_body": {"chat_template_kwargs": {"enable_thinking": True}}}
+        )
+        backend = Curator(cfg)._build_probe_backend()
+        assert backend.extra_body["chat_template_kwargs"]["enable_thinking"] is True
+
+    def test_refiner_default_forces_thinking_off(self):
+        cfg = _config()
+        backend = Curator(cfg)._build_refiner_backend()
+        assert backend.extra_body["chat_template_kwargs"]["enable_thinking"] is False
+
+
+class TestConcurrencyOverride:
+    def test_toxicity_backend_has_no_concurrency_knob_by_design(self):
+        # ToxicityGate.run() is a sequential loop with no executor — there is
+        # nothing to configure here yet; this documents that limitation.
+        cfg = _config()
+        curator = Curator(cfg)
+        assert curator._resolve_role_concurrency(cfg.toxicity_llm, cfg.judge_llm, 99) == 99
+
+    def test_probe_concurrency_default_is_32(self):
+        cfg = _config()
+        curator = Curator(cfg)
+        assert curator._resolve_role_concurrency(cfg.probe_llm, cfg.generator_llm, 32) == 32
+
+    def test_probe_concurrency_role_override_wins(self):
+        cfg = _config(probe_llm={"concurrency": 4})
+        curator = Curator(cfg)
+        assert curator._resolve_role_concurrency(cfg.probe_llm, cfg.generator_llm, 32) == 4
+
+    def test_probe_concurrency_falls_back_to_generator_llm_mid_tier(self):
+        cfg = _config(generator_llm={"concurrency": 7})
+        curator = Curator(cfg)
+        assert curator._resolve_role_concurrency(cfg.probe_llm, cfg.generator_llm, 32) == 7
+
+    def test_hallucination_gate_receives_resolved_concurrency(self):
+        cfg = _config(
+            hallucination_threshold=0.7,
+            hallucination_llm={"concurrency": 3},
+        )
+        curator = Curator(cfg)
+        steps = curator._build_steps()
+        from curatorkit.gates.hallucination import HallucinationGate
+
+        gate = next(s for s in steps if isinstance(s, HallucinationGate))
+        assert gate.concurrency == 3
+
+    def test_diagnostic_probe_receives_resolved_concurrency(self):
+        cfg = _config(
+            hallucination_threshold=0.7,
+            enable_diagnostic_probe=True,
+            probe_llm={"concurrency": 9},
+        )
+        curator = Curator(cfg)
+        steps = curator._build_steps()
+        from curatorkit.gates.hallucination import HallucinationGate
+
+        gate = next(s for s in steps if isinstance(s, HallucinationGate))
+        assert gate.probe is not None
+        assert gate.probe.concurrency == 9
+
+    def test_refiner_receives_resolved_concurrency(self):
+        cfg = _config(
+            reward_threshold=0.7,
+            enable_reward_refiner=True,
+            refiner_llm={"concurrency": 5},
+        )
+        curator = Curator(cfg)
+        curator._build_steps()
+        assert curator._reward_refiner is not None
+        assert curator._reward_refiner.concurrency == 5
+
+
+def _sentinel_llm(**overrides):
+    llm = MagicMock()
+    llm.temperature = 0.9191
+    llm.max_tokens = 9191
+    for k, v in overrides.items():
+        setattr(llm, k, v)
+    mock_response = MagicMock()
+    mock_response.text = '{"grounding_score": 1.0, "verdict": "supported", "overall_score": 1.0}'
+    llm.generate.return_value = mock_response
+    return llm
+
+
+class TestCallSitesReadFromBackendNotLiterals:
+    """Each of these call sites used to hardcode temperature=/max_tokens= directly
+    in the .generate() call, ignoring whatever the backend was configured with."""
+
+    def test_hallucination_gate_evaluate_grounding(self):
+        from curatorkit.gates.hallucination import HallucinationGate
+
+        gate = HallucinationGate(llm=_sentinel_llm())
+        gate._evaluate_grounding("source", "question", "answer")
+        _, kwargs = gate.llm.generate.call_args
+        assert kwargs["temperature"] == 0.9191
+        assert kwargs["max_tokens"] == 9191
+
+    def test_reward_gate_evaluate_quality(self):
+        from curatorkit.gates.reward import RewardGate
+
+        gate = RewardGate(llm=_sentinel_llm())
+        gate._evaluate_quality("instruction", "response")
+        _, kwargs = gate.llm.generate.call_args
+        assert kwargs["temperature"] == 0.9191
+        assert kwargs["max_tokens"] == 9191
+
+    def test_grpo_scoring_llm_score_single(self):
+        from curatorkit.generators.grpo_rollout import GRPORolloutTask
+
+        scoring_llm = _sentinel_llm()
+        scoring_llm.generate.return_value.text = '{"score": 0.8, "reasoning": "ok"}'
+        task = GRPORolloutTask(llm=MagicMock(), scoring_llm=scoring_llm)
+        task._score_single("instruction", "response")
+        _, kwargs = scoring_llm.generate.call_args
+        assert kwargs["temperature"] == 0.9191
+        assert kwargs["max_tokens"] == 9191
+
+    def test_probe_regenerate_max_tokens(self):
+        from curatorkit.diagnostic.probe import DiagnosticProbe
+        from curatorkit.schema import RejectedSample
+
+        generator_llm = _sentinel_llm()
+        generator_llm.generate.return_value.text = "regenerated answer"
+        probe = DiagnosticProbe(generator_llm=generator_llm, gate=MagicMock())
+        original = RejectedSample(
+            source_uri="test", instruction="q", rejection_reason="x", rejecting_step="x"
+        )
+        probe._regenerate(original, source_context="some source", temperature=0.42)
+        _, kwargs = generator_llm.generate.call_args
+        assert kwargs["temperature"] == 0.42  # temperature stays parametrized by caller
+        assert kwargs["max_tokens"] == 9191  # max_tokens now read from the backend
+
+    def test_probe_regenerate_instruction_max_tokens(self):
+        from curatorkit.diagnostic.probe import DiagnosticProbe
+        from curatorkit.schema import RejectedSample
+
+        generator_llm = _sentinel_llm()
+        generator_llm.generate.return_value.text = "regenerated question?"
+        probe = DiagnosticProbe(generator_llm=generator_llm, gate=MagicMock())
+        original = RejectedSample(
+            source_uri="test", instruction="q", rejection_reason="x", rejecting_step="x"
+        )
+        probe._regenerate_instruction(original, source_context="some source")
+        _, kwargs = generator_llm.generate.call_args
+        assert kwargs["max_tokens"] == 9191
+
+    def test_refiner_refine_answer(self):
+        from curatorkit.diagnostic.reward_refine import RewardRefiner
+        from curatorkit.schema import RejectedSample
+
+        generator_llm = _sentinel_llm()
+        generator_llm.generate.return_value.text = "refined answer"
+        refiner = RewardRefiner(generator_llm=generator_llm, reward_gate=MagicMock())
+        sample = RejectedSample(
+            source_uri="test",
+            instruction="q",
+            output="a",
+            rejection_reason="x",
+            rejecting_step="x",
+        )
+        refiner._refine_answer(sample, axis="helpfulness", weakness="too short")
+        _, kwargs = generator_llm.generate.call_args
+        assert kwargs["temperature"] == 0.9191
+        assert kwargs["max_tokens"] == 9191
+
+    def test_refiner_refine_instruction(self):
+        from curatorkit.diagnostic.reward_refine import RewardRefiner
+        from curatorkit.schema import RejectedSample
+
+        generator_llm = _sentinel_llm()
+        generator_llm.generate.return_value.text = "refined instruction?"
+        refiner = RewardRefiner(generator_llm=generator_llm, reward_gate=MagicMock())
+        sample = RejectedSample(
+            source_uri="test",
+            instruction="q",
+            output="a",
+            rejection_reason="x",
+            rejecting_step="x",
+        )
+        refiner._refine_instruction(sample, weakness="unclear")
+        _, kwargs = generator_llm.generate.call_args
+        assert kwargs["temperature"] == 0.9191
+        assert kwargs["max_tokens"] == 9191


### PR DESCRIPTION
## Summary

<!-- What does this PR do, and why? Link the issue it closes: Closes #123 -->

## Type of change

- [ ] Connector / data source
- [ ] Generation task
- [ ] Quality / hygiene gate
- [ ] Exporter
- [ ] Adaptive recovery / diagnostics
- [ ] CLI / YAML config
- [ ] Docs / tutorials
- [ ] Bug fix / refactor

## Checklist

- [ ] `ruff check .` passes
- [ ] `pytest tests/unit -q` passes
- [ ] Tests added or updated for behavior changes
- [ ] Docs updated (`docs/reference/configuration.md` if `CuratorConfig` changed, `docs/guides/exporters.md` if formats changed)
- [ ] `CHANGELOG.md` entry added under *Unreleased*
- [ ] No data files or pipeline outputs committed
