### PR TITLE
fixed recovery record for the gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ All notable changes to CuratorKIT are documented here. The format follows
   expected `overall_score`/`grounding_score` key silently scored every sample 0.0. Now falls back
   to averaging dimension scores or extracting a number from the raw response, warns immediately if
   a custom template omits the key, and warns again after a run if the fallback was actually used.
+- `enable_reward_refiner` recovery ran *after* exporters had already written files, so recovered
+  samples showed up in `CuratorResult.passed` but not in the exported `sft_alpaca.jsonl`/etc. (e.g.
+  13 initial passes + 2 recovered = 15 in memory, but 13 rows on disk). `Curator.run_async()` also
+  never invoked the refiner at all, so `enable_reward_refiner` had no effect when called directly
+  instead of through `run()`. Exporting is now deferred until after refiner recovery (and, when
+  configured, `output_split`) completes in both `run()` and `run_async()`.
 
 ## 1.0.0 - 2026-06-12
 

--- a/curatorkit/curator.py
+++ b/curatorkit/curator.py
@@ -60,6 +60,26 @@ except ImportError:
     PipelineDiagnostics = None  # type: ignore
 
 
+def _exporter_classes() -> dict[str, type]:
+    """Exporter registry shared by inline pipeline export, output_split
+    export, and post-recovery export, so all three stay in sync."""
+    from curatorkit.exporters.alpaca import AlpacaExporter
+    from curatorkit.exporters.corpus import CorpusExporter
+    from curatorkit.exporters.dpo import DPOExporter
+    from curatorkit.exporters.grpo import GRPOExporter
+    from curatorkit.exporters.ppo import PPOExporter
+    from curatorkit.exporters.sharegpt import ShareGPTExporter
+
+    return {
+        "alpaca": AlpacaExporter,
+        "corpus": CorpusExporter,
+        "sharegpt": ShareGPTExporter,
+        "dpo": DPOExporter,
+        "grpo": GRPOExporter,
+        "ppo": PPOExporter,
+    }
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # LLMOverride
 # ─────────────────────────────────────────────────────────────────────────────
@@ -619,6 +639,50 @@ class Curator:
         self._diagnostics = None
         self._reward_refiner = None
 
+    def _apply_reward_refiner(self, result) -> None:
+        """Run RewardRefiner recovery on RewardGate rejects, in place on `result`.
+
+        Must run before any exporting happens — see run()/run_async(), which
+        defer exporters (via _build_steps' include_exporters gate) until
+        after this call so recovered samples make it into the output files
+        instead of only into the in-memory CuratorResult.
+
+        Always records a "RewardRefiner" stage_counts entry whenever the
+        refiner is configured (even 0/0/0, if there was nothing to refine) —
+        so the manifest/dataset card show this stage ran, rather than the
+        recovery's contribution to the final `passed` count being invisible
+        next to every other reader/gate/normalizer, which all get a row.
+        `output_count` is always 0 and `rejected_count` always equals
+        `input_count`: unlike a gate, 100% of this stage's input already
+        failed elsewhere — there is no "clean pass" for a pure-recovery
+        stage, only `probe_recovered` (reused here for the same reason gates
+        use it: recovered samples that continue on are counted separately
+        from `output_count`, not folded into it).
+        """
+        if self._reward_refiner is None:
+            return
+        reward_rejects = [r for r in result.rejected if r.rejecting_step == "RewardGate"]
+        if not reward_rejects:
+            result.stage_counts["RewardRefiner"] = {
+                "input_count": 0,
+                "output_count": 0,
+                "probe_recovered": 0,
+                "rejected_count": 0,
+            }
+            return
+        recovered, still_rejected = self._reward_refiner.refine(reward_rejects)
+        result.passed.extend(recovered)
+        # Replace the original reward rejects with still-rejected ones
+        result.rejected = [
+            r for r in result.rejected if r.rejecting_step != "RewardGate"
+        ] + still_rejected
+        result.stage_counts["RewardRefiner"] = {
+            "input_count": len(reward_rejects),
+            "output_count": 0,
+            "probe_recovered": len(recovered),
+            "rejected_count": len(reward_rejects),
+        }
+
     def dry_run(self) -> list[dict[str, str]]:
         """
         Build the step list from CuratorConfig and print the plan without running.
@@ -655,18 +719,15 @@ class Curator:
         else:
             result = pipeline.run()
 
+        # Recovery must complete before anything is exported — otherwise
+        # exported files reflect the pre-recovery `passed` count while the
+        # returned CuratorResult reflects the post-recovery one.
+        self._apply_reward_refiner(result)
+
         if splitting:
             self._export_splits(result.passed, output_dir)
-
-        if self._reward_refiner is not None:
-            reward_rejects = [r for r in result.rejected if r.rejecting_step == "RewardGate"]
-            if reward_rejects:
-                recovered, still_rejected = self._reward_refiner.refine(reward_rejects)
-                result.passed.extend(recovered)
-                # Replace the original reward rejects with still-rejected ones
-                result.rejected = [
-                    r for r in result.rejected if r.rejecting_step != "RewardGate"
-                ] + still_rejected
+        elif self._reward_refiner is not None:
+            self._run_exporters(result.passed, output_dir)
 
         self._write_provenance(result, output_dir)
 
@@ -696,8 +757,16 @@ class Curator:
         pipeline = Pipeline(steps, output_dir=output_dir, diagnostics=self._diagnostics, checkpoint_mgr=ckpt)
         result = await pipeline.run_async()
 
+        # Recovery must complete before anything is exported — see run()'s
+        # comment. run_async() previously never ran the reward refiner at
+        # all, so enable_reward_refiner silently had no effect when callers
+        # used this entry point directly instead of run().
+        self._apply_reward_refiner(result)
+
         if splitting:
             self._export_splits(result.passed, output_dir)
+        elif self._reward_refiner is not None:
+            self._run_exporters(result.passed, output_dir)
 
         self._write_provenance(result, output_dir)
 
@@ -749,12 +818,6 @@ class Curator:
     # ═════════════════════════════════════════════════════════════════════════
 
     def _build_steps(self, include_exporters: bool = True) -> list:
-        from curatorkit.exporters.alpaca import AlpacaExporter
-        from curatorkit.exporters.corpus import CorpusExporter
-        from curatorkit.exporters.dpo import DPOExporter
-        from curatorkit.exporters.grpo import GRPOExporter
-        from curatorkit.exporters.ppo import PPOExporter
-        from curatorkit.exporters.sharegpt import ShareGPTExporter
         from curatorkit.gates.schema import SchemaGate
         from curatorkit.normalizers.clean import TextCleaner
         from curatorkit.normalizers.dedup import (
@@ -1048,16 +1111,16 @@ class Curator:
 
             steps.append(MaxSamplesTruncator(cfg.max_samples))
 
-        # ── Exporters (skipped when output_split is set — handled post-pipeline) ─
-        if include_exporters:
-            _exporter_map = {
-                "alpaca": AlpacaExporter,
-                "corpus": CorpusExporter,
-                "sharegpt": ShareGPTExporter,
-                "dpo": DPOExporter,
-                "grpo": GRPOExporter,
-                "ppo": PPOExporter,
-            }
+        # ── Exporters ────────────────────────────────────────────────────────
+        # Skipped inline when output_split is set (handled post-pipeline by
+        # _export_splits) or when a RewardRefiner was just built above: the
+        # refiner's recovered samples only get merged into `passed` *after*
+        # Pipeline.run()/run_async() returns, so an inline exporter step here
+        # would write files before recovery happens and miss those samples.
+        # run()/run_async() call _run_exporters() themselves once recovery
+        # (and, if configured, splitting) has finished.
+        if include_exporters and self._reward_refiner is None:
+            _exporter_map = _exporter_classes()
             for fmt in cfg.export_formats:
                 cls = _exporter_map.get(fmt.lower())
                 if cls:
@@ -1467,17 +1530,27 @@ class Curator:
     # Provenance
     # ─────────────────────────────────────────────────────────────────────────
 
+    def _run_exporters(self, samples: list, output_dir: Path) -> None:
+        """Write export_formats to disk directly, bypassing the pipeline's
+        inline exporter steps.
+
+        Used whenever exporters must run after the pipeline itself has
+        finished — currently: after RewardRefiner recovery — so the files
+        reflect samples merged into `passed` post-pipeline instead of a
+        stale pre-recovery snapshot.
+        """
+        _exporter_map = _exporter_classes()
+        for fmt in self.config.export_formats:
+            cls = _exporter_map.get(fmt.lower())
+            if cls:
+                cls().export(samples, output_dir)
+            else:
+                warnings.warn(f"Unknown export format '{fmt}' — skipped.")
+
     def _export_splits(self, samples: list, output_dir: Path) -> None:
         """Split accepted samples and export each split to suffixed files."""
         import math
         import random as _random
-
-        from curatorkit.exporters.alpaca import AlpacaExporter
-        from curatorkit.exporters.corpus import CorpusExporter
-        from curatorkit.exporters.dpo import DPOExporter
-        from curatorkit.exporters.grpo import GRPOExporter
-        from curatorkit.exporters.ppo import PPOExporter
-        from curatorkit.exporters.sharegpt import ShareGPTExporter
 
         split_def = self.config.output_split  # e.g. {"train": 0.8, "val": 0.1, "test": 0.1}
         total = sum(split_def.values())
@@ -1491,14 +1564,7 @@ class Curator:
         _random.Random(self.config.output_split_seed).shuffle(shuffled)
         n = len(shuffled)
 
-        _exporter_map = {
-            "alpaca": AlpacaExporter,
-            "corpus": CorpusExporter,
-            "sharegpt": ShareGPTExporter,
-            "dpo": DPOExporter,
-            "grpo": GRPOExporter,
-            "ppo": PPOExporter,
-        }
+        _exporter_map = _exporter_classes()
 
         start = 0
         split_items = list(split_def.items())

--- a/curatorkit/diagnostic/diagnostics.py
+++ b/curatorkit/diagnostic/diagnostics.py
@@ -13,7 +13,10 @@ Typical uses:
   mode_counts() and probe_recovery_count() feed the per-mode rejection
   breakdown written to diagnostic_summary.json; total_probe_calls()
   tracks the LLM budget the probe consumed, so recovery yield can be
-  cost-normalised.
+  cost-normalised. by_stage() breaks the same summary down per
+  rejecting_step (gate name) — the top-level totals pool every
+  probe-enabled gate together, which hides which gate's probe is actually
+  doing the recovering whenever more than one gate has a probe attached.
 """
 
 from __future__ import annotations
@@ -33,6 +36,27 @@ class PipelineDiagnostics:
     def record(self, sample: RejectedSample) -> None:
         self._diagnosed.append(sample)
 
+    @staticmethod
+    def _summarize(samples: list[RejectedSample]) -> dict[str, Any]:
+        """The to_dict()-shaped summary for one group of diagnosed samples —
+        shared by the pooled top-level totals and each by_stage() group so
+        the two can never drift out of sync."""
+        total = len(samples)
+        recovered = sum(
+            1 for s in samples if s.diagnosis is not None and s.diagnosis.recovered_sample is not None
+        )
+        mode_counter: Counter = Counter()
+        for s in samples:
+            mode_counter[s.diagnosis.mode.value if s.diagnosis else "undiagnosed"] += 1
+        probe_calls = sum(s.diagnosis.probe_calls for s in samples if s.diagnosis)
+        return {
+            "total_diagnosed": total,
+            "probe_recovered": recovered,
+            "probe_recovery_pct": round(recovered / total, 4) if total else 0.0,
+            "total_probe_calls": probe_calls,
+            "mode_counts": dict(mode_counter),
+        }
+
     def probe_recovery_count(self) -> int:
         """Number of samples where the probe produced an inline passing re-generation."""
         return sum(
@@ -50,16 +74,23 @@ class PipelineDiagnostics:
     def total_probe_calls(self) -> int:
         return sum(s.diagnosis.probe_calls for s in self._diagnosed if s.diagnosis)
 
+    def by_stage(self) -> dict[str, dict[str, Any]]:
+        """Per-rejecting_step (gate name) breakdown, each shaped like to_dict().
+
+        When both HallucinationGate and RewardGate have a probe attached,
+        the pooled totals can't tell you which gate's probe is actually
+        recovering samples — this splits the same summary by the gate that
+        rejected each sample.
+        """
+        stages: dict[str, list[RejectedSample]] = {}
+        for s in self._diagnosed:
+            stages.setdefault(s.rejecting_step, []).append(s)
+        return {stage: self._summarize(samples) for stage, samples in stages.items()}
+
     def to_dict(self) -> dict[str, Any]:
-        total = len(self._diagnosed)
-        recovered = self.probe_recovery_count()
-        return {
-            "total_diagnosed": total,
-            "probe_recovered": recovered,
-            "probe_recovery_pct": round(recovered / total, 4) if total else 0.0,
-            "total_probe_calls": self.total_probe_calls(),
-            "mode_counts": self.mode_counts(),
-        }
+        summary = self._summarize(self._diagnosed)
+        summary["by_stage"] = self.by_stage()
+        return summary
 
     def write_summary(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/curatorkit/manifest.py
+++ b/curatorkit/manifest.py
@@ -9,7 +9,12 @@ manifest.json top-level keys:
   pipeline_config_hash    SHA-256 of the full pipeline YAML config
   run_timestamp           ISO-8601 UTC
   source_files            list of {path, sha256}
-  stage_counts            {step_name: {input_count, output_count, rejected_count}}
+  stage_counts            {step_name: {input_count, output_count, rejected_count,
+                            probe_recovered?}} — probe_recovered is present on
+                            gates with an inline DiagnosticProbe attached, and
+                            on the synthetic "RewardRefiner" stage (added when
+                            enable_reward_refiner=True) whose recovery runs
+                            after the whole pipeline, not as a pipeline step.
   rejected_breakdown      {rejection_reason: count}
   dedup_stats             extracted from MinHashDeduplicator provenance notes
   minhash_threshold       float | null
@@ -221,10 +226,13 @@ class DatasetCardGenerator:
                 total_in = counts.get("input_count", 0)
                 passed = counts.get("output_count", 0)
                 rejected = counts.get("rejected_count", 0)
+                recovered = counts.get("probe_recovered", 0)
                 rate = f"{100 * passed / total_in:.1f}%" if total_in else "N/A"
-                gate_section += (
-                    f"- **{step}**: {passed}/{total_in} passed ({rate}), {rejected} rejected\n"
-                )
+                line = f"- **{step}**: {passed}/{total_in} passed ({rate})"
+                if recovered:
+                    line += f", {recovered} recovered"
+                line += f", {rejected} rejected\n"
+                gate_section += line
 
         rejection_detail = (
             "\n".join(
@@ -266,8 +274,8 @@ class DatasetCardGenerator:
 
 ## Pipeline Stages
 
-| Step | Input | Output | Rejected |
-|------|-------|--------|----------|
+| Step | Input | Passed | Recovered | Rejected | Forward |
+|------|-------|--------|-----------|----------|---------|
 {self._stage_table(stage_counts)}
 
 ## Gate Pass Rates and Rejection Breakdown
@@ -304,10 +312,25 @@ curatorkit run pipeline.yaml --output-dir ./out/
 """
 
     def _stage_table(self, stage_counts: dict[str, object]) -> str:
+        """Render one row per pipeline stage.
+
+        `Recovered` is `probe_recovered` when a stage set it (an inline
+        DiagnosticProbe on a gate, or the post-pipeline RewardRefiner) —
+        "—" otherwise. `Forward` is `Passed + Recovered`: the count that
+        actually continues into the next stage / the final `passed` set.
+        `Passed` alone understates that whenever recovery happened, since a
+        gate's own `output_count` never includes samples its probe rescued.
+        """
         rows = []
         for step, counts in stage_counts.items():
             inp = counts.get("input_count", counts.get("output_count", "—"))
             out = counts.get("output_count", counts.get("exported_count", "—"))
+            recovered = counts.get("probe_recovered")
             rej = counts.get("rejected_count", "—")
-            rows.append(f"| {step} | {inp} | {out} | {rej} |")
-        return "\n".join(rows) if rows else "| — | — | — | — |"
+            if isinstance(out, int) and isinstance(recovered, int):
+                forward = out + recovered
+            else:
+                forward = out
+            recovered_display = recovered if recovered is not None else "—"
+            rows.append(f"| {step} | {inp} | {out} | {recovered_display} | {rej} | {forward} |")
+        return "\n".join(rows) if rows else "| — | — | — | — | — | — |"

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -9,13 +9,15 @@ from curatorkit.diagnostic.failure_modes import FailureDiagnosis, FailureMode
 from curatorkit.schema import DataSample, RejectedSample
 
 
-def _make_diagnosed(mode: FailureMode, recovered: bool = False) -> RejectedSample:
+def _make_diagnosed(
+    mode: FailureMode, recovered: bool = False, rejecting_step: str = "HallucinationGate"
+) -> RejectedSample:
     s = RejectedSample(
         source_uri="test/doc",
         instruction="What?",
         output="An answer.",
         rejection_reason="below_threshold",
-        rejecting_step="HallucinationGate",
+        rejecting_step=rejecting_step,
     )
     recovered_sample = None
     if recovered:
@@ -111,3 +113,78 @@ class TestPipelineDiagnostics:
             assert path.exists()
             loaded = json.loads(path.read_text())
             assert loaded["total_diagnosed"] == 1
+
+    def test_to_dict_includes_by_stage(self):
+        d = PipelineDiagnostics()
+        d.record(_make_diagnosed(FailureMode.GENERATOR_TEMPERATURE))
+        result = d.to_dict()
+        assert "by_stage" in result
+
+
+class TestPipelineDiagnosticsByStage:
+    """Regression coverage for the per-gate breakdown: when both
+    HallucinationGate and RewardGate have a probe attached, the pooled
+    top-level totals can't tell you which gate's probe is actually
+    recovering samples — by_stage() splits that out.
+    """
+
+    def test_splits_by_rejecting_step(self):
+        d = PipelineDiagnostics()
+        # HallucinationGate: 2 diagnosed, 1 recovered
+        d.record(
+            _make_diagnosed(
+                FailureMode.GENERATOR_TEMPERATURE, recovered=True, rejecting_step="HallucinationGate"
+            )
+        )
+        d.record(
+            _make_diagnosed(
+                FailureMode.SOURCE_AMBIGUOUS, recovered=False, rejecting_step="HallucinationGate"
+            )
+        )
+        # RewardGate: 3 diagnosed, 2 recovered
+        d.record(
+            _make_diagnosed(
+                FailureMode.RESPONSE_QUALITY, recovered=True, rejecting_step="RewardGate"
+            )
+        )
+        d.record(
+            _make_diagnosed(
+                FailureMode.RESPONSE_QUALITY, recovered=True, rejecting_step="RewardGate"
+            )
+        )
+        d.record(
+            _make_diagnosed(
+                FailureMode.INSTRUCTION_QUALITY, recovered=False, rejecting_step="RewardGate"
+            )
+        )
+
+        by_stage = d.by_stage()
+
+        assert set(by_stage) == {"HallucinationGate", "RewardGate"}
+        assert by_stage["HallucinationGate"]["total_diagnosed"] == 2
+        assert by_stage["HallucinationGate"]["probe_recovered"] == 1
+        assert by_stage["HallucinationGate"]["probe_recovery_pct"] == 0.5
+        assert by_stage["RewardGate"]["total_diagnosed"] == 3
+        assert by_stage["RewardGate"]["probe_recovered"] == 2
+        assert round(by_stage["RewardGate"]["probe_recovery_pct"], 4) == round(2 / 3, 4)
+
+        # Pooled top-level totals must still equal the sum across stages —
+        # by_stage() is a breakdown, not a replacement for the pooled figures.
+        pooled = d.to_dict()
+        assert pooled["total_diagnosed"] == 5
+        assert pooled["probe_recovered"] == 3
+
+    def test_by_stage_mode_counts_are_scoped_to_their_stage(self):
+        d = PipelineDiagnostics()
+        d.record(
+            _make_diagnosed(FailureMode.GENERATOR_TEMPERATURE, rejecting_step="HallucinationGate")
+        )
+        d.record(_make_diagnosed(FailureMode.RESPONSE_QUALITY, rejecting_step="RewardGate"))
+
+        by_stage = d.by_stage()
+        assert by_stage["HallucinationGate"]["mode_counts"] == {"generator_temperature": 1}
+        assert by_stage["RewardGate"]["mode_counts"] == {"response_quality": 1}
+
+    def test_empty_diagnostics_has_no_stages(self):
+        d = PipelineDiagnostics()
+        assert d.by_stage() == {}

--- a/tests/unit/test_manifest_stage_reporting.py
+++ b/tests/unit/test_manifest_stage_reporting.py
@@ -1,0 +1,140 @@
+"""
+Tests for the stage-wise reporting added to manifest.json / dataset_card.md.
+
+Before this, a gate's `output_count` never included samples its inline
+probe recovered, and the post-pipeline RewardRefiner had no stage_counts
+entry at all — so neither manifest.json nor dataset_card.md could show how
+much a stage's recovery mechanism actually contributed to the final yield,
+only the raw aggregate pass/reject totals.
+"""
+
+from __future__ import annotations
+
+from curatorkit.manifest import DatasetCardGenerator, ProvenanceManifest
+from curatorkit.pipeline import PipelineResult
+from curatorkit.schema import DataSample
+
+
+def _result(stage_counts: dict) -> PipelineResult:
+    return PipelineResult(
+        passed=[DataSample(source_uri="t://", instruction="q", output="a")],
+        rejected=[],
+        stage_counts=stage_counts,
+        wall_clock_seconds=1.0,
+    )
+
+
+class TestStageTableRecoveredAndForwardColumns:
+    def test_gate_with_probe_recovery_shows_recovered_and_forward(self):
+        result = _result(
+            {
+                "HallucinationGate": {
+                    "input_count": 20,
+                    "output_count": 15,
+                    "probe_recovered": 3,
+                    "rejected_count": 5,
+                }
+            }
+        )
+        manifest = ProvenanceManifest(result).build()
+        table = DatasetCardGenerator()._stage_table(manifest["stage_counts"])
+
+        assert "| HallucinationGate | 20 | 15 | 3 | 5 | 18 |" == table
+
+    def test_gate_without_probe_shows_dash_for_recovered_and_passed_for_forward(self):
+        result = _result(
+            {
+                "SchemaGate": {
+                    "input_count": 20,
+                    "output_count": 18,
+                    "rejected_count": 2,
+                }
+            }
+        )
+        manifest = ProvenanceManifest(result).build()
+        table = DatasetCardGenerator()._stage_table(manifest["stage_counts"])
+
+        assert "| SchemaGate | 20 | 18 | — | 2 | 18 |" == table
+
+    def test_reward_refiner_stage_shows_zero_passed_full_recovered_as_forward(self):
+        """RewardRefiner's own stage entry: output_count=0 (no "clean pass"
+        concept — every sample here already failed elsewhere), so Forward
+        should equal probe_recovered alone.
+        """
+        result = _result(
+            {
+                "RewardRefiner": {
+                    "input_count": 10,
+                    "output_count": 0,
+                    "probe_recovered": 5,
+                    "rejected_count": 10,
+                }
+            }
+        )
+        manifest = ProvenanceManifest(result).build()
+        table = DatasetCardGenerator()._stage_table(manifest["stage_counts"])
+
+        assert "| RewardRefiner | 10 | 0 | 5 | 10 | 5 |" == table
+
+    def test_empty_stage_counts_renders_six_dash_columns(self):
+        table = DatasetCardGenerator()._stage_table({})
+        assert table == "| — | — | — | — | — | — |"
+
+
+class TestDatasetCardGateSection:
+    def test_recovered_count_appears_in_gate_pass_rate_line(self):
+        result = _result(
+            {
+                "HallucinationGate": {
+                    "input_count": 20,
+                    "output_count": 15,
+                    "probe_recovered": 3,
+                    "rejected_count": 5,
+                }
+            }
+        )
+        manifest = ProvenanceManifest(result).build()
+        card = DatasetCardGenerator()._render(manifest, "test_pipeline")
+
+        assert "**HallucinationGate**: 15/20 passed (75.0%), 3 recovered, 5 rejected" in card
+
+    def test_no_recovered_clause_when_stage_has_no_probe(self):
+        result = _result(
+            {
+                "SchemaGate": {
+                    "input_count": 20,
+                    "output_count": 18,
+                    "rejected_count": 2,
+                }
+            }
+        )
+        manifest = ProvenanceManifest(result).build()
+        card = DatasetCardGenerator()._render(manifest, "test_pipeline")
+
+        assert "- **SchemaGate**: 18/20 passed (90.0%), 2 rejected\n" in card
+
+    def test_reward_refiner_row_present_in_full_card(self):
+        """End-to-end sanity check for the reported bug's own numbers: 18
+        into RewardGate, 8 pass cleanly, 10 rejected, 5 recovered by the
+        refiner -> Forward column shows the true final yield of 13 (8 + 5).
+        """
+        result = _result(
+            {
+                "RewardGate": {
+                    "input_count": 18,
+                    "output_count": 8,
+                    "rejected_count": 10,
+                },
+                "RewardRefiner": {
+                    "input_count": 10,
+                    "output_count": 0,
+                    "probe_recovered": 5,
+                    "rejected_count": 10,
+                },
+            }
+        )
+        manifest = ProvenanceManifest(result).build()
+        card = DatasetCardGenerator()._render(manifest, "test_pipeline")
+
+        assert "| RewardGate | 18 | 8 | — | 10 | 8 |" in card
+        assert "| RewardRefiner | 10 | 0 | 5 | 10 | 5 |" in card

--- a/tests/unit/test_reward_refiner_export_order.py
+++ b/tests/unit/test_reward_refiner_export_order.py
@@ -1,0 +1,160 @@
+"""
+Regression test: RewardRefiner-recovered samples must land in exported
+files, not just in the returned CuratorResult.
+
+Reported bug: 18 samples generated -> RewardGate passes 13, rejects 5 ->
+RewardRefiner recovers 2 of the 5 -> CuratorResult.passed has 15, but
+sft_alpaca.jsonl on disk only has 13 rows.
+
+Root cause: Curator._build_steps() appends exporters as the last pipeline
+step, so they run *inside* Pipeline.run()/run_async() using the pre-recovery
+`passed` list. RewardRefiner recovery only happens in Curator.run(), *after*
+Pipeline.run()/run_async() has already returned (and already exported) —
+so exported files reflect the stale 13-sample snapshot. Curator.run_async()
+additionally never invoked the refiner at all, so enable_reward_refiner had
+zero effect when a caller used that entry point directly.
+
+The fix: Curator._build_steps() skips the inline exporter step whenever a
+RewardRefiner was built for this run, and Curator.run()/run_async() run the
+refiner first and export afterwards (via the new _run_exporters helper),
+using the post-recovery sample list in both places.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from curatorkit.curator import Curator, CuratorConfig
+from curatorkit.exporters.alpaca import AlpacaExporter
+from curatorkit.interfaces import BaseGate, BaseReader
+from curatorkit.schema import DataSample, RejectedSample
+
+_NUM_SAMPLES = 18
+_NUM_REWARD_PASSED = 13
+_NUM_RECOVERED = 2
+_NUM_TOTAL_EXPECTED = _NUM_REWARD_PASSED + _NUM_RECOVERED  # 15
+
+
+class _FakeReader(BaseReader):
+    def read(self):
+        samples = [
+            DataSample(source_uri="t://fake", instruction=f"q{i}", output=f"a{i}")
+            for i in range(_NUM_SAMPLES)
+        ]
+        return samples, []
+
+
+class _FakeRewardGate(BaseGate):
+    """Mirrors the reported split: 13 pass, 5 rejected by RewardGate."""
+
+    def run(self, samples):
+        passed = samples[:_NUM_REWARD_PASSED]
+        rejected = [
+            RejectedSample(
+                **s.model_dump(exclude={"rejection_reason", "rejecting_step"}),
+                rejection_reason="below_reward_threshold:0.4",
+                rejecting_step="RewardGate",
+            )
+            for s in samples[_NUM_REWARD_PASSED:]
+        ]
+        return passed, rejected
+
+
+class _FakeRefiner:
+    """Mirrors the reported split: 2 of the 5 rejects recover, 3 stay rejected."""
+
+    def refine(self, rejected):
+        recovered = [
+            DataSample(
+                source_uri=r.source_uri,
+                instruction=r.instruction,
+                output=f"refined-{r.output}",
+            )
+            for r in rejected[:_NUM_RECOVERED]
+        ]
+        still_rejected = rejected[_NUM_RECOVERED:]
+        return recovered, still_rejected
+
+
+def _rig_curator(tmp_path):
+    """Build a Curator whose _build_steps is swapped for a minimal fake
+    pipeline (reader -> reward gate -> inline exporter), with a fake
+    RewardRefiner attached.
+
+    The inline AlpacaExporter step is deliberately unconditional here (unlike
+    the real, fixed _build_steps, which now skips it whenever a refiner is
+    active) so this harness reproduces the reported symptom precisely: an
+    exporter that runs inline on the pre-recovery `passed` list, writing 13
+    rows to disk. It isolates what actually changed for this fix — the
+    ordering/dispatch in Curator.run()/run_async() — from _build_steps'
+    own exporter-skipping logic, which is exercised separately by the
+    existing _build_steps-level tests.
+    """
+    cfg = CuratorConfig(
+        dataset="unused",
+        output_dir=str(tmp_path),
+        export_formats=["alpaca"],
+        enable_reward_refiner=True,
+    )
+    curator = Curator(cfg)
+
+    def _fake_build_steps(self, include_exporters=True):
+        self._reward_refiner = _FakeRefiner()
+        steps = [_FakeReader(), _FakeRewardGate()]
+        if include_exporters:
+            steps.append(AlpacaExporter())
+        return steps
+
+    curator._build_steps = _fake_build_steps.__get__(curator, Curator)
+    return curator
+
+
+class TestRewardRefinerExportOrderSync:
+    def test_result_passed_includes_recovered_samples(self, tmp_path):
+        curator = _rig_curator(tmp_path)
+        result = curator.run()
+        assert len(result.passed) == _NUM_TOTAL_EXPECTED
+
+    def test_exported_file_includes_recovered_samples(self, tmp_path):
+        curator = _rig_curator(tmp_path)
+        curator.run()
+
+        alpaca_path = tmp_path / "sft_alpaca.jsonl"
+        assert alpaca_path.exists()
+        lines = alpaca_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == _NUM_TOTAL_EXPECTED
+
+        records = [json.loads(line) for line in lines]
+        outputs = {r["output"] for r in records}
+        assert "refined-a13" in outputs
+        assert "refined-a14" in outputs
+
+    def test_stage_counts_records_reward_refiner_recovery(self, tmp_path):
+        """Recovery is otherwise invisible: the RewardGate's own stage_counts
+        entry doesn't shrink when the refiner later saves some of its
+        rejects, and RewardRefiner isn't a Pipeline step, so without this
+        entry nothing in the manifest/dataset card would show that 2 of the
+        5 RewardGate rejects were recovered after the fact.
+        """
+        curator = _rig_curator(tmp_path)
+        result = curator.run()
+
+        assert "RewardRefiner" in result.stage_counts
+        refiner_counts = result.stage_counts["RewardRefiner"]
+        assert refiner_counts["input_count"] == 5
+        assert refiner_counts["probe_recovered"] == _NUM_RECOVERED
+        assert refiner_counts["rejected_count"] == 5
+
+
+class TestRewardRefinerExportOrderAsync:
+    def test_run_async_applies_refiner_and_exports_recovered_samples(self, tmp_path):
+        curator = _rig_curator(tmp_path)
+        result = asyncio.run(curator.run_async())
+
+        assert len(result.passed) == _NUM_TOTAL_EXPECTED
+
+        alpaca_path = tmp_path / "sft_alpaca.jsonl"
+        assert alpaca_path.exists()
+        lines = alpaca_path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == _NUM_TOTAL_EXPECTED


### PR DESCRIPTION
## Summary

<!-- What does this PR do, and why? Link the issue it closes: Closes #123 -->

## Type of change

- [ ] Connector / data source
- [ ] Generation task
- [ ] Quality / hygiene gate
- [ ] Exporter
- [ ] Adaptive recovery / diagnostics
- [ ] CLI / YAML config
- [ ] Docs / tutorials
- [ ] Bug fix / refactor

## Checklist

- [ ] `ruff check .` passes
- [ ] `pytest tests/unit -q` passes
- [ ] Tests added or updated for behavior changes
- [ ] Docs updated (`docs/reference/configuration.md` if `CuratorConfig` changed, `docs/guides/exporters.md` if formats changed)
- [ ] `CHANGELOG.md` entry added under *Unreleased*
- [ ] No data files or pipeline outputs committed
